### PR TITLE
feat: allow custom documentation links in dashboard

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -528,6 +528,17 @@ deploykf_core:
       ##
       externalLinks: []
 
+      ## links that appear in the home page
+      ##  - a list of extra links to appear in the dashboard
+      ##  - each element is a map with the following keys:
+      ##     - `text`: the text that appears in the homepage (example: "deployKF Website")
+      ##     - `desc`: the description which appears below (example: "The tool that deployed your ML platform!")
+      ##     - `link`: the url to navigate to when the link is clicked (example: "https://deploykf.org")
+      ##
+      documentationItems:
+        - text: deployKF Website
+          desc: The tool that deployed your ML platform!
+          link: https://github.com/deployKF/deployKF
 
   ## --------------------------------------
   ##        deploykf-istio-gateway

--- a/generator/templates/manifests/deploykf-core/deploykf-dashboard/values.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-dashboard/values.yaml
@@ -149,9 +149,11 @@ centralDashboard:
     ## documentation links that appear in the home page
     ##
     documentationItems:
-      - text: deployKF Website
-        desc: The tool that deployed your ML platform!
-        link: https://github.com/deployKF/deployKF
+      {{<- range $externalLink := .Values.deploykf_core.deploykf_dashboard.navigation.documentationItems >}}
+      - text: {{< $externalLink.text | quote >}}
+        desc: {{< $externalLink.desc | quote >}}
+        link: {{< $externalLink.link | quote >}}
+      {{<- end >}}
       {{<- if .Values.kubeflow_tools.pipelines.enabled >}}
       - text: Kubeflow Pipelines Documentation
         desc: Documentation for Kubeflow Pipelines


### PR DESCRIPTION
Similar to links in the sidebar, this commit updates the values files to allow configuring the documentation links section on the dashboard home page.

Adds the `deploykf_core.deploykf_dashboard.navigation.documentationItems` value, which is a list of links.