### PR TITLE
fix: set `securityContext.fsGroup` on minio pods

### DIFF
--- a/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Deployment.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Deployment.yaml
@@ -44,7 +44,12 @@ spec:
       affinity: {}
       tolerations: []
       serviceAccountName: deploykf-minio
+      {{- if .Values.minio.podSecurityContext }}
+      securityContext:
+        {{- .Values.minio.podSecurityContext | toYaml | nindent 8 }}
+      {{- else }}
       securityContext: {}
+      {{- end }}
       initContainers: []
       containers:
         - name: minio

--- a/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Job-create-buckets.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Job-create-buckets.yaml
@@ -31,7 +31,12 @@ spec:
       affinity: {}
       tolerations: []
       serviceAccountName: deploykf-minio-jobs
+      {{- if .Values.minio.podSecurityContext }}
+      securityContext:
+        {{- .Values.minio.podSecurityContext | toYaml | nindent 8 }}
+      {{- else }}
       securityContext: {}
+      {{- end }}
       initContainers: []
       containers:
         - name: create-buckets

--- a/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Job-create-policies.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Job-create-policies.yaml
@@ -31,7 +31,12 @@ spec:
       affinity: {}
       tolerations: []
       serviceAccountName: deploykf-minio-jobs
+      {{- if .Values.minio.podSecurityContext }}
+      securityContext:
+        {{- .Values.minio.podSecurityContext | toYaml | nindent 8 }}
+      {{- else }}
       securityContext: {}
+      {{- end }}
       initContainers: []
       containers:
         - name: create-policies

--- a/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Job-create-service-accounts.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Job-create-service-accounts.yaml
@@ -36,7 +36,12 @@ spec:
       affinity: {}
       tolerations: []
       serviceAccountName: deploykf-minio-jobs
+      {{- if .Values.minio.podSecurityContext }}
+      securityContext:
+        {{- .Values.minio.podSecurityContext | toYaml | nindent 8 }}
+      {{- else }}
       securityContext: {}
+      {{- end }}
       initContainers:
         - name: copy-kubectl
           image: {{ .Values.minio.kubectlImage.repository }}:{{ .Values.minio.kubectlImage.tag }}

--- a/generator/templates/manifests/deploykf-opt/deploykf-minio/values.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-minio/values.yaml
@@ -88,6 +88,14 @@ minio:
     uid: 1000
     gid: 1000
 
+  ## the securityContext configs for minio Pods
+  ## - spec for PodSecurityContext:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core
+  ##
+  podSecurityContext:
+    ## sets filesystem owner group of in mounted volumes, ensuring pod has permissions to read data
+    fsGroup: 1000
+
   ## resource requests/limits for the minio Pods
   ## - spec for ResourceRequirements:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

This PR addresses permission issues that may be encountered for some kinds of PVC StorageClasses used by the MinIO pods by setting PodSecurityContext `fsGroup` to `1000`.

__NOTE:__ this fix was [already applied to MySQL](https://github.com/deployKF/deployKF/blob/v0.1.0/generator/templates/manifests/deploykf-opt/deploykf-mysql/values.yaml#L46-L52), but was missed on the MinIO pods.