### PR TITLE
feat: allow a single ArgoCD to manage deployKF across multiple clusters

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -5,6 +5,13 @@
 ## --------------------------------------------------------------------------------
 argocd:
 
+  ## a prefix to use for argocd application names
+  ##  - allows a single instance of argocd to manage deployKF across multiple clusters
+  ##  - if non-empty, `argocd.destination` must be a remote cluster, this is because
+  ##    a single cluster can only have one instance of deployKF
+  ##
+  appNamePrefix: ""
+
   ## the namespace in which argocd is deployed
   ##
   namespace: argocd
@@ -47,9 +54,11 @@ argocd:
       path: ""
 
   ## the destination used for deployKF argocd applications
+  ##  - the value of `destination.name` takes precedence over `destination.server`
   ##
   destination:
     server: https://kubernetes.default.svc
+    name: ""
 
 
 ## --------------------------------------------------------------------------------

--- a/generator/helpers/check-values--incompatible-configs.tpl
+++ b/generator/helpers/check-values--incompatible-configs.tpl
@@ -3,6 +3,23 @@
 
 ## --------------------------------------------------------------------------------
 ##
+##                                      argocd
+##
+## --------------------------------------------------------------------------------
+{{<- if .Values.argocd.appNamePrefix >}}
+  {{<- if .Values.argocd.destination.name >}}
+    {{<- if eq .Values.argocd.destination.name "in-cluster" >}}
+      {{< fail "`argocd.destination.name` can not be 'in-cluster' if `argocd.appNamePrefix` is set, a single cluster can only have one instance of deployKF" >}}
+    {{<- end >}}
+  {{<- else >}}
+    {{<- if eq .Values.argocd.destination.server "https://kubernetes.default.svc" >}}
+      {{< fail "`argocd.destination.server` can not be 'https://kubernetes.default.svc' if `argocd.appNamePrefix` is set, a single cluster can only have one instance of deployKF" >}}
+    {{<- end >}}
+  {{<- end >}}
+{{<- end >}}
+
+## --------------------------------------------------------------------------------
+##
 ##                              kubeflow-dependencies
 ##
 ## --------------------------------------------------------------------------------

--- a/generator/templates/app-of-apps.yaml
+++ b/generator/templates/app-of-apps.yaml
@@ -2,11 +2,11 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: deploykf-app-of-apps
+  name: {{< print .Values.argocd.appNamePrefix "deploykf-app-of-apps" | quote >}}
   namespace: {{< .Values.argocd.namespace | quote >}}
   labels:
     app.kubernetes.io/name: deploykf-app-of-apps
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
 spec:
   project: {{< .Values.argocd.project | quote >}}
   source:
@@ -20,6 +20,10 @@ spec:
     targetRevision: {{< .Values.argocd.source.repo.revision | quote >}}
     path: {{< path.Join .Values.argocd.source.repo.path "argocd" | quote >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: {{< .Values.argocd.namespace | quote >}}
 {{<- end >}}

--- a/generator/templates/argocd/deploykf-core/deploykf-auth.yaml
+++ b/generator/templates/argocd/deploykf-core/deploykf-auth.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: deploykf-auth
     app.kubernetes.io/component: deploykf-core
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -27,7 +27,11 @@ spec:
         - values-overrides.yaml
   {{<- end >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: {{< .Values.deploykf_core.deploykf_auth.namespace | quote >}}
   syncPolicy:
     syncOptions:

--- a/generator/templates/argocd/deploykf-core/deploykf-dashboard.yaml
+++ b/generator/templates/argocd/deploykf-core/deploykf-dashboard.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: deploykf-dashboard
     app.kubernetes.io/component: deploykf-core
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -27,5 +27,9 @@ spec:
         - values-overrides.yaml
   {{<- end >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: {{< .Values.deploykf_core.deploykf_dashboard.namespace | quote >}}

--- a/generator/templates/argocd/deploykf-core/deploykf-istio-gateway.yaml
+++ b/generator/templates/argocd/deploykf-core/deploykf-istio-gateway.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: deploykf-istio-gateway
     app.kubernetes.io/component: deploykf-core
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -27,5 +27,9 @@ spec:
         - values-overrides.yaml
   {{<- end >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: {{< .Values.deploykf_core.deploykf_istio_gateway.namespace | quote >}}

--- a/generator/templates/argocd/deploykf-core/deploykf-profiles-generator.yaml
+++ b/generator/templates/argocd/deploykf-core/deploykf-profiles-generator.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: deploykf-profiles-generator
     app.kubernetes.io/component: deploykf-core
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -27,7 +27,11 @@ spec:
         - values-overrides.yaml
   {{<- end >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: kubeflow
   ignoreDifferences:
     ## `rules` are aggregated when `aggregationRule.clusterRoleSelectors` is set

--- a/generator/templates/argocd/deploykf-dependencies/cert-manager.yaml
+++ b/generator/templates/argocd/deploykf-dependencies/cert-manager.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/component: deploykf-dependencies
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -27,5 +27,9 @@ spec:
         - values-overrides.yaml
   {{<- end >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: {{< .Values.deploykf_dependencies.cert_manager.namespace | quote >}}

--- a/generator/templates/argocd/deploykf-dependencies/istio.yaml
+++ b/generator/templates/argocd/deploykf-dependencies/istio.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: istio
     app.kubernetes.io/component: deploykf-dependencies
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -27,7 +27,11 @@ spec:
         - values-overrides.yaml
   {{<- end >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: {{< .Values.deploykf_dependencies.istio.namespace | quote >}}
   ignoreDifferences:
     ## istio patches the `failurePolicy` from "Ignore" to "Fail" once the webhook is up

--- a/generator/templates/argocd/deploykf-dependencies/kyverno.yaml
+++ b/generator/templates/argocd/deploykf-dependencies/kyverno.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kyverno
     app.kubernetes.io/component: deploykf-dependencies
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -27,7 +27,11 @@ spec:
         - values-overrides.yaml
   {{<- end >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: {{< .Values.deploykf_dependencies.kyverno.namespace | quote >}}
   syncPolicy:
     syncOptions:

--- a/generator/templates/argocd/deploykf-opt/deploykf-minio.yaml
+++ b/generator/templates/argocd/deploykf-opt/deploykf-minio.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: deploykf-minio
     app.kubernetes.io/component: deploykf-opt
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -27,7 +27,11 @@ spec:
         - values-overrides.yaml
   {{<- end >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: {{< .Values.deploykf_opt.deploykf_minio.namespace | quote >}}
   syncPolicy:
     syncOptions:

--- a/generator/templates/argocd/deploykf-opt/deploykf-mysql.yaml
+++ b/generator/templates/argocd/deploykf-opt/deploykf-mysql.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: deploykf-mysql
     app.kubernetes.io/component: deploykf-opt
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -27,7 +27,11 @@ spec:
         - values-overrides.yaml
   {{<- end >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: {{< .Values.deploykf_opt.deploykf_mysql.namespace | quote >}}
   syncPolicy:
     syncOptions:

--- a/generator/templates/argocd/kubeflow-dependencies/kubeflow-argo-workflows.yaml
+++ b/generator/templates/argocd/kubeflow-dependencies/kubeflow-argo-workflows.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubeflow-argo-workflows
     app.kubernetes.io/component: kubeflow-dependencies
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -27,7 +27,11 @@ spec:
         - values-overrides.yaml
   {{<- end >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: {{< .Values.kubeflow_dependencies.kubeflow_argo_workflows.namespace | quote >}}
   syncPolicy:
     syncOptions:

--- a/generator/templates/argocd/kubeflow-tools/katib.yaml
+++ b/generator/templates/argocd/kubeflow-tools/katib.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: katib
     app.kubernetes.io/component: kubeflow-tools
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -22,7 +22,11 @@ spec:
     path: {{< path.Join .Values.argocd.source.repo.path $generator_folder_path | quote >}}
   {{<- end >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: kubeflow
   syncPolicy:
     syncOptions:

--- a/generator/templates/argocd/kubeflow-tools/notebooks--jupyter-web-app.yaml
+++ b/generator/templates/argocd/kubeflow-tools/notebooks--jupyter-web-app.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: jupyter-web-app
     app.kubernetes.io/component: kubeflow-tools
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -22,5 +22,9 @@ spec:
     path: {{< path.Join .Values.argocd.source.repo.path $generator_folder_path | quote >}}
   {{<- end >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: kubeflow

--- a/generator/templates/argocd/kubeflow-tools/notebooks--notebook-controller.yaml
+++ b/generator/templates/argocd/kubeflow-tools/notebooks--notebook-controller.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: notebook-controller
     app.kubernetes.io/component: kubeflow-tools
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -22,7 +22,11 @@ spec:
     path: {{< path.Join .Values.argocd.source.repo.path $generator_folder_path | quote >}}
   {{<- end >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: kubeflow
   ignoreDifferences:
     ## `rules` are aggregated when `aggregationRule.clusterRoleSelectors` is set

--- a/generator/templates/argocd/kubeflow-tools/pipelines.yaml
+++ b/generator/templates/argocd/kubeflow-tools/pipelines.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: pipelines
     app.kubernetes.io/component: kubeflow-tools
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -22,7 +22,11 @@ spec:
     path: {{< path.Join .Values.argocd.source.repo.path $generator_folder_path | quote >}}
   {{<- end >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: kubeflow
   syncPolicy:
     syncOptions:

--- a/generator/templates/argocd/kubeflow-tools/poddefaults-webhook.yaml
+++ b/generator/templates/argocd/kubeflow-tools/poddefaults-webhook.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: poddefaults-webhook
     app.kubernetes.io/component: kubeflow-tools
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -22,7 +22,11 @@ spec:
     path: {{< path.Join .Values.argocd.source.repo.path $generator_folder_path | quote >}}
   {{<- end >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: kubeflow
   ignoreDifferences:
     ## `caBundle` is injected by cert-manager

--- a/generator/templates/argocd/kubeflow-tools/tensorboards--tensorboard-controller.yaml
+++ b/generator/templates/argocd/kubeflow-tools/tensorboards--tensorboard-controller.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tensorboard-controller
     app.kubernetes.io/component: kubeflow-tools
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -22,5 +22,9 @@ spec:
     path: {{< path.Join .Values.argocd.source.repo.path $generator_folder_path | quote >}}
   {{<- end >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: kubeflow

--- a/generator/templates/argocd/kubeflow-tools/tensorboards--tensorboards-web-app.yaml
+++ b/generator/templates/argocd/kubeflow-tools/tensorboards--tensorboards-web-app.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tensorboards-web-app
     app.kubernetes.io/component: kubeflow-tools
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -22,5 +22,9 @@ spec:
     path: {{< path.Join .Values.argocd.source.repo.path $generator_folder_path | quote >}}
   {{<- end >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: kubeflow

--- a/generator/templates/argocd/kubeflow-tools/training-operator.yaml
+++ b/generator/templates/argocd/kubeflow-tools/training-operator.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: training-operator
     app.kubernetes.io/component: kubeflow-tools
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -22,7 +22,11 @@ spec:
     path: {{< path.Join .Values.argocd.source.repo.path $generator_folder_path | quote >}}
   {{<- end >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: kubeflow
   ignoreDifferences:
     ## `rules` are aggregated when `aggregationRule.clusterRoleSelectors` is set

--- a/generator/templates/argocd/kubeflow-tools/volumes--volumes-web-app.yaml
+++ b/generator/templates/argocd/kubeflow-tools/volumes--volumes-web-app.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: volumes-web-app
     app.kubernetes.io/component: kubeflow-tools
-    app.kubernetes.io/part-of: deploykf
+    app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -22,5 +22,9 @@ spec:
     path: {{< path.Join .Values.argocd.source.repo.path $generator_folder_path | quote >}}
   {{<- end >}}
   destination:
+    {{<- if .Values.argocd.destination.name >}}
+    name: {{< .Values.argocd.destination.name | quote >}}
+    {{<- else >}}
     server: {{< .Values.argocd.destination.server | quote >}}
+    {{<- end >}}
     namespace: kubeflow

--- a/generator/templates/argocd/kustomization.yaml
+++ b/generator/templates/argocd/kustomization.yaml
@@ -101,3 +101,17 @@ resources:
   {{<- if .Values.kubeflow_tools.volumes.enabled >}}
   - kubeflow-tools/volumes--volumes-web-app.yaml
   {{<- end >}}
+
+{{<- if .Values.argocd.appNamePrefix >}}
+transformers:
+  - |
+    apiVersion: builtin
+    kind: PrefixSuffixTransformer
+    metadata:
+      name: argocd-app-name-prefix
+    prefix: {{< .Values.argocd.appNamePrefix | quote >}}
+    fieldSpecs:
+      - apiVersion: argoproj.io/v1alpha1
+        kind: Application
+        path: metadata/name
+{{<- end >}}

--- a/generator/templates/manifests/kubeflow-tools/pipelines/resources/generate-profile-resources-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/resources/generate-profile-resources-clusterpolicy.yaml
@@ -1,6 +1,6 @@
 ## this ClusterPolicy replaces the `pipelines-profile-controller` from the upstream manifests
 ## https://github.com/kubeflow/pipelines/tree/2.0.0-alpha.7/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller
-{{<- $argocd_app_name := "kf-tools--pipelines" >}}
+{{<- $argocd_app_name := print .Values.argocd.appNamePrefix "kf-tools--pipelines" >}}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/sample-values.yaml
+++ b/sample-values.yaml
@@ -5,6 +5,13 @@
 ## --------------------------------------------------------------------------------
 argocd:
 
+  ## a prefix to use for argocd application names
+  ##  - allows a single instance of argocd to manage deployKF across multiple clusters
+  ##  - if non-empty, `argocd.destination` must be a remote cluster, this is because
+  ##    a single cluster can only have one instance of deployKF
+  ##
+  appNamePrefix: ""
+
   ## the namespace in which argocd is deployed
   ##
   namespace: argocd
@@ -38,9 +45,11 @@ argocd:
       path: ""
 
   ## the destination used for deployKF argocd applications
+  ##  - the value of `destination.name` takes precedence over `destination.server`
   ##
   destination:
     server: https://kubernetes.default.svc
+    name: ""
 
 
 ## --------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

This PR enables a single instance of ArgoCD to manage deployKF across multiple clusters. 

For example, it is common to have an ArgoCD "management cluster" which deploys applications to other Kubernetes clusters, so those clusters don't need to have ArgoCD installed separately.

This is achieved by adding the following values:
- `argocd.appNamePrefix`: 
    - Previously you could only apply one instance of the deployKF ArgoCD Applications to a cluster (as the names would overlap), this value lets you prefix the application names.
- `argocd.destination.name`:
    - Allows setting the `spec.destination.name` of the Application resources, in addition to our already existing `argocd.destination.server` value for setting `spec.destination.server`.