### PR TITLE
fix: minio-console user permissions (update minio)

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -842,12 +842,12 @@ deploykf_opt:
     images:
       minio:
         repository: docker.io/minio/minio
-        tag: RELEASE.2023-07-07T07-13-57Z
+        tag: RELEASE.2023-08-04T17-40-21Z
         pullPolicy: IfNotPresent
 
       minioMc:
         repository: docker.io/minio/mc
-        tag: RELEASE.2023-07-07T05-25-51Z
+        tag: RELEASE.2023-08-01T23-30-57Z
         pullPolicy: IfNotPresent
 
       kubectl:


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR updates the default minio container image tags. This is mainly to pick up the fix for https://github.com/minio/console/issues/2929, which was preventing users from downloading files that they should have had access to (due to a UI glitch).

The new default image tags are:
- `minio/minio`: `RELEASE.2023-08-04T17-40-21Z`
- `minio/mc`: `RELEASE.2023-08-01T23-30-57Z`