### PR TITLE
fix: resolve cert-manager race conditions

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -98,8 +98,9 @@ deploykf_dependencies:
 
       trustManager:
         name: trust-manager
-        version: 0.5.0
-        repository: https://charts.jetstack.io
+        ## NOTE: we fork the upstream trust-manager chart to fix race conditions with cert-manager
+        version: 0.5.0-deploykf
+        repository: file://forks/trust-manager
 
     ## image overrides
     ##

--- a/generator/templates/argocd/deploykf-dependencies/cert-manager.yaml
+++ b/generator/templates/argocd/deploykf-dependencies/cert-manager.yaml
@@ -33,3 +33,11 @@ spec:
     server: {{< .Values.argocd.destination.server | quote >}}
     {{<- end >}}
     namespace: {{< .Values.deploykf_dependencies.cert_manager.namespace | quote >}}
+  syncPolicy:
+    ## retry is needed because cert-manager can take time to generate certificates
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 6m

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/.helmignore
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/.helmignore
@@ -43,3 +43,6 @@ Sessionx.vim
 .hg/
 .hgignore
 .svn/
+
+## Chart Forks
+forks/

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/Chart.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/Chart.yaml
@@ -1,0 +1,19 @@
+annotations:
+  artifacthub.io/prerelease: "false"
+apiVersion: v2
+appVersion: v0.5.0
+description: trust-manager is the easiest way to manage TLS trust bundles in Kubernetes
+  and OpenShift clusters
+home: https://github.com/cert-manager/trust-manager
+kubeVersion: '>= 1.22.0-0'
+maintainers:
+- email: cert-manager-maintainers@googlegroups.com
+  name: cert-manager-maintainers
+  url: https://cert-manager.io
+name: trust-manager
+sources:
+- https://github.com/cert-manager/trust-manager
+type: application
+#################### BEGIN CHANGE ####################
+version: 0.5.0-deploykf
+##################### END CHANGE #####################

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/FORK.md
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/FORK.md
@@ -1,0 +1,17 @@
+# About this Fork
+
+This is a fork of the upstream [trust-manager](https://github.com/cert-manager/trust-manager/tree/main/deploy/charts/trust-manager) Helm chart for use in deployKF.
+
+__The changes made in this fork are:__
+
+- the chart version has been suffixed with `-deploykf`, to avoid confusion with the upstream chart
+- added the `app.deploymentAnnotations` value (used to set `argocd.argoproj.io/sync-wave` to resolve race conditions on sync)
+- added the `app.certificateAnnotations` value (used to set `argocd.argoproj.io/sync-wave` to resolve race conditions on sync)
+
+To aid in the maintenance of this fork, all places where changes have been made are wrapped as follows:
+
+```yaml
+#################### BEGIN CHANGE ####################
+...
+##################### END CHANGE #####################
+```

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/NOTES.txt
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/NOTES.txt
@@ -1,0 +1,15 @@
+trust-manager {{ .Chart.AppVersion }} has been deployed successfully!
+
+{{- if .Values.defaultPackage.enabled }}
+Your installation includes a default CA package, using the following
+default CA package image:
+
+{{ .Values.defaultPackageImage.repository }}:{{ .Values.defaultPackageImage.tag }}
+
+It's imperative that you keep the default CA package image up to date.
+{{- end }}
+To find out more about securely running trust-manager and to get started
+with creating your first bundle, check out the documentation on the
+cert-manager website:
+
+https://cert-manager.io/docs/projects/trust-manager/

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/_helpers.tpl
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "trust-manager.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "trust-manager.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "trust-manager.labels" -}}
+app.kubernetes.io/name: {{ include "trust-manager.name" . }}
+helm.sh/chart: {{ include "trust-manager.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/certificate.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/certificate.yaml
@@ -1,0 +1,35 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
+  #################### BEGIN CHANGE ####################
+  annotations:
+    {{- toYaml .Values.app.certificateAnnotations | nindent 4 }}
+  ##################### END CHANGE #####################
+  labels:
+{{ include "trust-manager.labels" . | indent 4 }}
+
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
+  #################### BEGIN CHANGE ####################
+  annotations:
+    {{- toYaml .Values.app.certificateAnnotations | nindent 4 }}
+  ##################### END CHANGE #####################
+  labels:
+{{ include "trust-manager.labels" . | indent 4 }}
+spec:
+  dnsNames:
+  - "{{ include "trust-manager.name" . }}.{{ .Release.Namespace }}.svc"
+  secretName: {{ include "trust-manager.name" . }}-tls
+  revisionHistoryLimit: 1
+  issuerRef:
+    name: {{ include "trust-manager.name" . }}
+    kind: Issuer
+    group: cert-manager.io

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/clusterrole.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/clusterrole.yaml
@@ -1,0 +1,44 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+{{ include "trust-manager.labels" . | indent 4 }}
+  name: {{ include "trust-manager.name" . }}
+rules:
+- apiGroups:
+  - "trust.cert-manager.io"
+  resources:
+  - "bundles"
+  verbs: ["get", "list", "watch"]
+
+# Permissions to update finalizers are required for trust-manager to work correctly
+# on OpenShift, even though we don't directly use finalizers at the time of writing
+- apiGroups:
+  - "trust.cert-manager.io"
+  resources:
+  - "bundles/finalizers"
+  verbs: ["update"]
+
+- apiGroups:
+  - "trust.cert-manager.io"
+  resources:
+  - "bundles/status"
+  verbs: ["update"]
+
+- apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  verbs: ["get", "list", "create", "update", "watch", "delete"]
+
+- apiGroups:
+  - ""
+  resources:
+  - "namespaces"
+  verbs: ["get", "list", "watch"]
+
+- apiGroups:
+  - ""
+  resources:
+  - "events"
+  verbs: ["create", "patch"]

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/clusterrolebinding.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+{{ include "trust-manager.labels" . | indent 4 }}
+  name: {{ include "trust-manager.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "trust-manager.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ .Release.Namespace }}

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/deployment.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/deployment.yaml
@@ -1,0 +1,116 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
+  #################### BEGIN CHANGE ####################
+  annotations:
+    {{- toYaml .Values.app.deploymentAnnotations | nindent 4 }}
+  ##################### END CHANGE #####################
+  labels:
+{{ include "trust-manager.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "trust-manager.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "trust-manager.name" . }}
+    spec:
+      serviceAccountName: {{ include "trust-manager.name" . }}
+      {{- if .Values.defaultPackage.enabled }}
+      initContainers:
+      - name: cert-manager-package-debian
+        image: "{{ .Values.defaultPackageImage.repository }}:{{ .Values.defaultPackageImage.tag }}"
+        imagePullPolicy: {{ .Values.defaultPackageImage.pullPolicy }}
+        args:
+          - "/copyandmaybepause"
+          - "/debian-package"
+          - "/packages"
+        volumeMounts:
+        - mountPath: /packages
+          name: packages
+          readOnly: false
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+      {{- end }}
+      containers:
+      - name: {{ include "trust-manager.name" . }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.app.webhook.port }}
+        - containerPort: {{ .Values.app.metrics.port }}
+        readinessProbe:
+          httpGet:
+            port: {{ .Values.app.readinessProbe.port }}
+            path: {{ .Values.app.readinessProbe.path }}
+          initialDelaySeconds: 3
+          periodSeconds: 7
+        command: ["trust-manager"]
+        args:
+          - "--log-level={{.Values.app.logLevel}}"
+          - "--metrics-port={{.Values.app.metrics.port}}"
+          - "--readiness-probe-port={{.Values.app.readinessProbe.port}}"
+          - "--readiness-probe-path={{.Values.app.readinessProbe.path}}"
+            # trust
+          - "--trust-namespace={{.Values.app.trust.namespace}}"
+            # webhook
+          - "--webhook-host={{.Values.app.webhook.host}}"
+          - "--webhook-port={{.Values.app.webhook.port}}"
+          - "--webhook-certificate-dir=/tls"
+          {{- if .Values.defaultPackage.enabled }}
+          - "--default-package-location=/packages/cert-manager-package-debian.json"
+          {{- end }}
+        volumeMounts:
+        - mountPath: /tls
+          name: tls
+          readOnly: true
+        - mountPath: /packages
+          name: packages
+          readOnly: true
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          {{- if .Values.app.securityContext.seccompProfileEnabled }}
+          seccompProfile:
+            type: RuntimeDefault
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with  .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: packages
+        emptyDir: {}
+      - name: tls
+        secret:
+          defaultMode: 420
+          secretName: {{ include "trust-manager.name" . }}-tls

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/metrics-service.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/metrics-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.app.metrics.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "trust-manager.name" . }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "trust-manager.name" . }}
+{{ include "trust-manager.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.app.metrics.service.type }}
+  ports:
+    - port: {{ .Values.app.metrics.port }}
+      targetPort: {{ .Values.app.metrics.port }}
+      protocol: TCP
+      name: metrics
+  selector:
+    app: {{ include "trust-manager.name" . }}
+{{- end }}

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/metrics-servicemonitor.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/metrics-servicemonitor.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.app.metrics.service.enabled .Values.app.metrics.service.servicemonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "trust-manager.name" . }}
+{{ include "trust-manager.labels" . | indent 4 }}
+    prometheus: {{ .Values.app.metrics.service.servicemonitor.prometheusInstance }}
+{{- if .Values.app.metrics.service.servicemonitor.labels }}
+{{ toYaml .Values.app.metrics.service.servicemonitor.labels | indent 4}}
+{{- end }}
+spec:
+  jobLabel: {{ include "trust-manager.name" . }}
+  selector:
+    matchLabels:
+      app: {{ include "trust-manager.name" . }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+  - targetPort: {{ .Values.app.metrics.port }}
+    path: "/metrics"
+    interval: {{ .Values.app.metrics.service.servicemonitor.interval }}
+    scrapeTimeout: {{ .Values.app.metrics.service.servicemonitor.scrapeTimeout }}
+{{- end }}

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/role.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/role.yaml
@@ -1,0 +1,26 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ .Values.app.trust.namespace }}
+  labels:
+{{ include "trust-manager.labels" . | indent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - "leases"
+  verbs:
+  - "get"
+  - "create"
+  - "update"
+  - "watch"
+  - "list"

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/rolebinding.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ .Values.app.trust.namespace }}
+  labels:
+{{ include "trust-manager.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "trust-manager.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ .Release.Namespace }}

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/serviceaccount.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "trust-manager.labels" . | indent 4 }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/trust.cert-manager.io_bundles.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/trust.cert-manager.io_bundles.yaml
@@ -1,0 +1,207 @@
+{{ if .Values.crds.enabled }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: bundles.trust.cert-manager.io
+spec:
+  group: trust.cert-manager.io
+  names:
+    kind: Bundle
+    listKind: BundleList
+    plural: bundles
+    singular: bundle
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Bundle Target Key
+          jsonPath: .status.target.configMap.key
+          name: Target
+          type: string
+        - description: Bundle has been synced
+          jsonPath: .status.conditions[?(@.type == "Synced")].status
+          name: Synced
+          type: string
+        - description: Reason Bundle has Synced status
+          jsonPath: .status.conditions[?(@.type == "Synced")].reason
+          name: Reason
+          type: string
+        - description: Timestamp Bundle was created
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the Bundle resource.
+              type: object
+              required:
+                - sources
+                - target
+              properties:
+                sources:
+                  description: Sources is a set of references to data whose data will sync to the target.
+                  type: array
+                  items:
+                    description: BundleSource is the set of sources whose data will be appended and synced to the BundleTarget in all Namespaces.
+                    type: object
+                    properties:
+                      configMap:
+                        description: ConfigMap is a reference to a ConfigMap's `data` key, in the trust Namespace.
+                        type: object
+                        required:
+                          - key
+                          - name
+                        properties:
+                          key:
+                            description: Key is the key of the entry in the object's `data` field to be used.
+                            type: string
+                          name:
+                            description: Name is the name of the source object in the trust Namespace.
+                            type: string
+                      inLine:
+                        description: InLine is a simple string to append as the source data.
+                        type: string
+                      secret:
+                        description: Secret is a reference to a Secrets's `data` key, in the trust Namespace.
+                        type: object
+                        required:
+                          - key
+                          - name
+                        properties:
+                          key:
+                            description: Key is the key of the entry in the object's `data` field to be used.
+                            type: string
+                          name:
+                            description: Name is the name of the source object in the trust Namespace.
+                            type: string
+                      useDefaultCAs:
+                        description: UseDefaultCAs, when true, requests the default CA bundle to be used as a source. Default CAs are available if trust-manager was installed via Helm or was otherwise set up to include a package-injecting init container by using the "--default-package-location" flag when starting the trust-manager controller. If default CAs were not configured at start-up, any request to use the default CAs will fail. The version of the default CA package which is used for a Bundle is stored in the defaultCAPackageVersion field of the Bundle's status field.
+                        type: boolean
+                target:
+                  description: Target is the target location in all namespaces to sync source data to.
+                  type: object
+                  properties:
+                    additionalFormats:
+                      description: AdditionalFormats specifies any additional formats to write to the target
+                      type: object
+                      properties:
+                        jks:
+                          description: KeySelector is a reference to a key for some map data object.
+                          type: object
+                          required:
+                            - key
+                          properties:
+                            key:
+                              description: Key is the key of the entry in the object's `data` field to be used.
+                              type: string
+                    configMap:
+                      description: ConfigMap is the target ConfigMap in Namespaces that all Bundle source data will be synced to.
+                      type: object
+                      required:
+                        - key
+                      properties:
+                        key:
+                          description: Key is the key of the entry in the object's `data` field to be used.
+                          type: string
+                    namespaceSelector:
+                      description: NamespaceSelector will, if set, only sync the target resource in Namespaces which match the selector.
+                      type: object
+                      properties:
+                        matchLabels:
+                          description: MatchLabels matches on the set of labels that must be present on a Namespace for the Bundle target to be synced there.
+                          type: object
+                          additionalProperties:
+                            type: string
+            status:
+              description: Status of the Bundle. This is set and managed automatically.
+              type: object
+              properties:
+                conditions:
+                  description: List of status conditions to indicate the status of the Bundle. Known condition types are `Bundle`.
+                  type: array
+                  items:
+                    description: BundleCondition contains condition information for a Bundle.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details of the last transition, complementing reason.
+                        type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Bundle.
+                        type: integer
+                        format: int64
+                      reason:
+                        description: Reason is a brief machine readable explanation for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of ('True', 'False', 'Unknown').
+                        type: string
+                      type:
+                        description: Type of the condition, known values are (`Synced`).
+                        type: string
+                defaultCAVersion:
+                  description: DefaultCAPackageVersion, if set and non-empty, indicates the version information which was retrieved when the set of default CAs was requested in the bundle source. This should only be set if useDefaultCAs was set to "true" on a source, and will be the same for the same version of a bundle with identical certificates.
+                  type: string
+                target:
+                  description: Target is the current Target that the Bundle is attempting or has completed syncing the source data to.
+                  type: object
+                  properties:
+                    additionalFormats:
+                      description: AdditionalFormats specifies any additional formats to write to the target
+                      type: object
+                      properties:
+                        jks:
+                          description: KeySelector is a reference to a key for some map data object.
+                          type: object
+                          required:
+                            - key
+                          properties:
+                            key:
+                              description: Key is the key of the entry in the object's `data` field to be used.
+                              type: string
+                    configMap:
+                      description: ConfigMap is the target ConfigMap in Namespaces that all Bundle source data will be synced to.
+                      type: object
+                      required:
+                        - key
+                      properties:
+                        key:
+                          description: Key is the key of the entry in the object's `data` field to be used.
+                          type: string
+                    namespaceSelector:
+                      description: NamespaceSelector will, if set, only sync the target resource in Namespaces which match the selector.
+                      type: object
+                      properties:
+                        matchLabels:
+                          description: MatchLabels matches on the set of labels that must be present on a Namespace for the Bundle target to be synced there.
+                          type: object
+                          additionalProperties:
+                            type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}
+{{ end }}

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/webhook.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/webhook.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "trust-manager.name" . }}
+{{ include "trust-manager.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.app.webhook.service.type }}
+  ports:
+    - port: 443
+      targetPort: {{ .Values.app.webhook.port }}
+{{- if .Values.app.webhook.service.nodePort }}
+      nodePort: {{ .Values.app.webhook.service.nodePort }}
+{{- end }}
+      protocol: TCP
+      name: webhook
+  selector:
+    app: {{ include "trust-manager.name" . }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  labels:
+    app: {{ include "trust-manager.name" . }}
+{{ include "trust-manager.labels" . | indent 4 }}
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "trust-manager.name" . }}"
+
+webhooks:
+  - name: trust.cert-manager.io
+    rules:
+      - apiGroups:
+          - "trust.cert-manager.io"
+        apiVersions:
+          - "*"
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - "*/*"
+    admissionReviewVersions: ["v1"]
+    timeoutSeconds: {{ .Values.app.webhook.timeoutSeconds }}
+    failurePolicy: Fail
+    sideEffects: None
+    clientConfig:
+      service:
+        name: {{ include "trust-manager.name" . }}
+        namespace: {{ .Release.Namespace | quote }}
+        path: /validate

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/values.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/values.yaml
@@ -1,0 +1,134 @@
+# -- Number of replicas of trust to run.
+replicaCount: 1
+
+# -- For Private docker registries, authentication is needed. Registry secrets are applied to the service account
+imagePullSecrets: []
+
+image:
+  # -- Target image repository.
+  repository: quay.io/jetstack/trust-manager
+  # -- Target image version tag.
+  tag: v0.5.0
+  # -- Kubernetes imagePullPolicy on Deployment.
+  pullPolicy: IfNotPresent
+
+defaultPackage:
+  # -- Whether to load the default trust package during pod initialization and include it in main container args. This container enables the 'useDefaultCAs' source on Bundles.
+  enabled: true
+
+defaultPackageImage:
+  # -- Repository for the default package image. This image enables the 'useDefaultCAs' source on Bundles.
+  repository: quay.io/jetstack/cert-manager-package-debian
+  # -- Tag for the default package image
+  tag: "20210119.0"
+  # -- imagePullPolicy for the default package image
+  pullPolicy: IfNotPresent
+
+app:
+  #################### BEGIN CHANGE ####################
+  # -- Annotations for the trust-manager Deployment
+  deploymentAnnotations: {}
+  # -- Annotations for the Certificate/Issuer resources created by trust-manager
+  certificateAnnotations: {}
+  ##################### END CHANGE #####################
+
+  # -- Verbosity of trust logging; takes a value from 1-5, with higher being more verbose
+  logLevel: 1
+
+  metrics:
+    # -- Port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'.
+    port: 9402
+    # -- Service to expose metrics endpoint.
+    service:
+      # -- Create a Service resource to expose metrics endpoint.
+      enabled: true
+      # -- Service type to expose metrics.
+      type: ClusterIP
+      # -- ServiceMonitor resource for this Service.
+      servicemonitor:
+        enabled: false
+        prometheusInstance: default
+        interval: 10s
+        scrapeTimeout: 5s
+        labels: {}
+
+  readinessProbe:
+    # -- Container port on which to expose trust HTTP readiness probe using default network interface.
+    port: 6060
+    # -- Path on which to expose trust HTTP readiness probe using default network interface.
+    path: "/readyz"
+
+  trust:
+    # -- Namespace used as trust source. Note that the namespace _must_ exist
+    # before installing trust-manager.
+    namespace: cert-manager
+
+  webhook:
+    # -- Host that the webhook listens on.
+    host: 0.0.0.0
+    # -- Port that the webhook listens on.
+    port: 6443
+    # -- Timeout of webhook HTTP request.
+    timeoutSeconds: 5
+    # -- Type of Kubernetes Service used by the Webhook
+    service:
+      type: ClusterIP
+
+  securityContext:
+    # -- If false, disables the default seccomp profile, which might be required to run on certain platforms
+    seccompProfileEnabled: true
+
+resources: {}
+  # -- Kubernetes pod resource limits for trust.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # -- Kubernetes pod memory resource requests for trust.
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# -- Configure the nodeSelector; defaults to any Linux node (trust-manager doesn't support Windows nodes)
+nodeSelector:
+  kubernetes.io/os: linux
+
+# Kubernetes Affinty; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#affinity-v1-core
+# for example:
+#   affinity:
+#     nodeAffinity:
+#      requiredDuringSchedulingIgnoredDuringExecution:
+#        nodeSelectorTerms:
+#        - matchExpressions:
+#          - key: foo.bar.com/role
+#            operator: In
+#            values:
+#            - master
+# -- Kubernetes Affinty; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#affinity-v1-core
+affinity: {}
+
+# List of Kubernetes Tolerations, if required; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core
+# for example:
+#   tolerations:
+#   - key: foo.bar.com/role
+#     operator: Equal
+#     value: master
+#     effect: NoSchedule
+# -- List of Kubernetes Tolerations; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core
+tolerations: []
+
+# List of Kubernetes TopologySpreadConstraints; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core
+# for example:
+#   topologySpreadConstraints:
+#   - maxSkew: 2
+#     topologyKey: topology.kubernetes.io/zone
+#     whenUnsatisfiable: ScheduleAnyway
+#     labelSelector:
+#       matchLabels:
+#         app.kubernetes.io/instance: cert-manager
+#         app.kubernetes.io/component: controller
+# -- List of Kubernetes TopologySpreadConstraints; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core
+topologySpreadConstraints: []
+
+crds:
+  # -- Whether or not to install the crds.
+  enabled: true

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/templates/ClusterIssuer-kubeflow-gateway-issuer.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/templates/ClusterIssuer-kubeflow-gateway-issuer.yaml
@@ -3,6 +3,10 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: {{ .Values.deployKF.certManager.clusterIssuer.issuerName | quote }}
+  annotations:
+    ## we must sync cert-manager resources after cert-manager itself
+    ## NOTE: this ClusterIssuer must come AFTER the 'selfsigned-ca-issuer' Certificate
+    argocd.argoproj.io/sync-wave: "13"
 spec:
   ca:
     secretName: {{ .Values.deployKF.certManager.clusterIssuer.selfSigned.caSecretName | quote }}

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/templates/selfsigned-ca-issuer/Bundle.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/templates/selfsigned-ca-issuer/Bundle.yaml
@@ -3,6 +3,10 @@ apiVersion: trust.cert-manager.io/v1alpha1
 kind: Bundle
 metadata:
   name: {{ .Values.deployKF.certManager.clusterIssuer.selfSigned.injectedConfigMapName | quote }}
+  annotations:
+    ## we must sync trust-manager resources after trust-manager itself
+    ## NOTE: this Bundle must come AFTER the 'selfsigned-ca-issuer' Certificate
+    argocd.argoproj.io/sync-wave: "30"
 spec:
   sources:
     - secret:

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/templates/selfsigned-ca-issuer/Certificate.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/templates/selfsigned-ca-issuer/Certificate.yaml
@@ -3,6 +3,10 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ .Values.deployKF.certManager.clusterIssuer.selfSigned.caIssuerName | quote }}
+  annotations:
+    ## we must sync cert-manager resources after cert-manager itself
+    ## NOTE: this Certificate must come AFTER the 'selfsigned-ca-issuer' Issuer
+    argocd.argoproj.io/sync-wave: "11"
 spec:
   isCA: true
   commonName: {{ .Values.deployKF.certManager.clusterIssuer.selfSigned.caIssuerName | quote }}

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/templates/selfsigned-ca-issuer/Issuer.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/templates/selfsigned-ca-issuer/Issuer.yaml
@@ -3,6 +3,10 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ .Values.deployKF.certManager.clusterIssuer.selfSigned.caIssuerName | quote }}
+  annotations:
+    ## we must sync cert-manager resources after cert-manager itself
+    ## NOTE: we create this Issuer FIRST, because other Certificates and Issuers depend on it
+    argocd.argoproj.io/sync-wave: "10"
 spec:
   selfSigned: {}
 {{- end }}

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/values.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/values.yaml
@@ -84,6 +84,27 @@ cert-manager:
       {{<- end >}}
       pullPolicy: {{< .Values.deploykf_dependencies.cert_manager.images.certManagerCtl.pullPolicy | quote >}}
 
+    jobAnnotations:
+      ## this job will block the main sync wave until the webhook is ready to create certificates,
+      ## by default this hook would run PostSync (helm: post-install), which is too late
+      argocd.argoproj.io/hook: Sync
+      argocd.argoproj.io/sync-wave: "1"
+      argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
+
+    rbac:
+      annotations:
+        ## we ensure the RBAC resources have earlier sync-wave than the job
+        argocd.argoproj.io/hook: Sync
+        argocd.argoproj.io/sync-wave: "0"
+        argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
+
+    serviceAccount:
+      annotations:
+        ## we ensure the ServiceAccount resources have earlier sync-wave than the job
+        argocd.argoproj.io/hook: Sync
+        argocd.argoproj.io/sync-wave: "0"
+        argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
+
 
 ########################################
 ## DEPENDENCY | trust-manager
@@ -108,5 +129,13 @@ trust-manager:
     pullPolicy: {{< .Values.deploykf_dependencies.cert_manager.images.trustManagerDefaultPackage.pullPolicy | quote >}}
 
   app:
+    certificateAnnotations:
+      ## we must sync cert-manager resources after cert-manager itself
+      argocd.argoproj.io/sync-wave: "10"
+
+    deploymentAnnotations:
+      ## we must sync the trust-manager deployment after its certificate is ready
+      argocd.argoproj.io/sync-wave: "20"
+
     trust:
       namespace: {{< .Values.deploykf_dependencies.cert_manager.namespace | quote >}}


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

resolves https://github.com/deployKF/deployKF/issues/23

This PR resolves a number of race conditions when installing/upgrading the cert-manager app:

1. Ensures `Certificates` and `Issuers` are sequenced correctly.
2. Ensures that `cert-manager` is up, before `trust-manager` is synced
      - __WARNING:__ this required forking the `trust-manager` helm chart, which will require an updated version of the deployKF ArgoCD Plugin (from PR https://github.com/deployKF/deployKF/pull/29)
3. Adds a default ArgoCD sync retry (because even with proper sequencing, stuff can still take time to provision)