### PR TITLE
fix: argocd plugin with "file://" dependencies (needed for helm forks)

### DIFF
--- a/argocd-plugin/argocd-install/deploykf-plugin/plugin.yaml
+++ b/argocd-plugin/argocd-install/deploykf-plugin/plugin.yaml
@@ -127,8 +127,8 @@ spec:
         
             ## add the helm repos for the chart dependencies
             helm dependency list --max-col-width 10000 "$OUTPUT_HELM_PATH" | awk 'NR>1 {print $1,$3}' | while read -r name url; do
-                if [[ -n "$name" && -n "$url" ]]; then
-                    helm repo add "$name" "$url"
+                if [[ -n "$name" && -n "$url" && "$url" =~ "^https?://" ]]; then
+                    helm repo add "$name" "$url" --force-update
                 fi
             done
         


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

required for https://github.com/deployKF/deployKF/pull/28

This PR fixes the following issues in the deployKF ArgoCD Plugin:

- helm charts with `file://` dependencies should not fail (only add `http(s)://` ones)
- updating the `repository` of a dependency should not fail (adds `--force-update`)