### PR TITLE
fix: ensure namespaces are never deleted or pruned

### DIFF
--- a/generator/templates/argocd/namespaces/kustomization.yaml
+++ b/generator/templates/argocd/namespaces/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonAnnotations:
+  ## NOTE: this ensures Namespaces are not deleted or pruned by ArgoCD (users can still delete them manually)
+  argocd.argoproj.io/sync-options: Delete=false,Prune=false
 resources:
   ###########################
   ## deploykf-dependencies ##


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

Because users may store other things in the deployKF namespaces (especially the ones for dependencies), we should never automatically delete them.

This PR ensures that ArgoCD will never "prune" (on sync) or "delete" (on app uninstall) a namespace.

__WARNING:__ this does NOT apply to the profile namespaces, which the profile controller will delete as soon as their `Profile` cluster-resource is removed. 