### PR TITLE
fix: add sync waves to argocd apps (fix deletion)

### DIFF
--- a/generator/templates/argocd/applications/deploykf-core/deploykf-auth.yaml
+++ b/generator/templates/argocd/applications/deploykf-core/deploykf-auth.yaml
@@ -4,6 +4,9 @@ kind: Application
 metadata:
   name: dkf-core--deploykf-auth
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## applications in 'deploykf-core' come after 'deploykf-dependencies'
+    argocd.argoproj.io/sync-wave: "21"
   labels:
     app.kubernetes.io/name: deploykf-auth
     app.kubernetes.io/component: deploykf-core

--- a/generator/templates/argocd/applications/deploykf-core/deploykf-dashboard.yaml
+++ b/generator/templates/argocd/applications/deploykf-core/deploykf-dashboard.yaml
@@ -4,6 +4,9 @@ kind: Application
 metadata:
   name: dkf-core--deploykf-dashboard
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## applications in 'deploykf-core' come after 'deploykf-dependencies'
+    argocd.argoproj.io/sync-wave: "21"
   labels:
     app.kubernetes.io/name: deploykf-dashboard
     app.kubernetes.io/component: deploykf-core

--- a/generator/templates/argocd/applications/deploykf-core/deploykf-istio-gateway.yaml
+++ b/generator/templates/argocd/applications/deploykf-core/deploykf-istio-gateway.yaml
@@ -4,6 +4,10 @@ kind: Application
 metadata:
   name: dkf-core--deploykf-istio-gateway
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## applications in 'deploykf-core' come after 'deploykf-dependencies'
+    ## NOTE: 'deploykf-istio-gateway' must come FIRST, as other 'deploykf-core' applications depend on it
+    argocd.argoproj.io/sync-wave: "20"
   labels:
     app.kubernetes.io/name: deploykf-istio-gateway
     app.kubernetes.io/component: deploykf-core

--- a/generator/templates/argocd/applications/deploykf-core/deploykf-profiles-generator.yaml
+++ b/generator/templates/argocd/applications/deploykf-core/deploykf-profiles-generator.yaml
@@ -4,6 +4,10 @@ kind: Application
 metadata:
   name: dkf-core--deploykf-profiles-generator
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## applications in 'deploykf-core' come after 'deploykf-dependencies'
+    ## NOTE: 'deploykf-profiles-generator' must come AFTER 'deploykf-dashboard', because the latter contains the profile controller
+    argocd.argoproj.io/sync-wave: "23"
   labels:
     app.kubernetes.io/name: deploykf-profiles-generator
     app.kubernetes.io/component: deploykf-core

--- a/generator/templates/argocd/applications/deploykf-dependencies/cert-manager.yaml
+++ b/generator/templates/argocd/applications/deploykf-dependencies/cert-manager.yaml
@@ -4,6 +4,10 @@ kind: Application
 metadata:
   name: dkf-dep--cert-manager
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## applications in 'deploykf-dependencies' come first
+    ## NOTE: in this group, each application has a separate wave to avoid conflicts due to webhooks
+    argocd.argoproj.io/sync-wave: "10"
   labels:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/component: deploykf-dependencies

--- a/generator/templates/argocd/applications/deploykf-dependencies/istio.yaml
+++ b/generator/templates/argocd/applications/deploykf-dependencies/istio.yaml
@@ -4,6 +4,10 @@ kind: Application
 metadata:
   name: dkf-dep--istio
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## applications in 'deploykf-dependencies' come first
+    ## NOTE: in this group, each application has a separate wave to avoid conflicts due to webhooks
+    argocd.argoproj.io/sync-wave: "11"
   labels:
     app.kubernetes.io/name: istio
     app.kubernetes.io/component: deploykf-dependencies

--- a/generator/templates/argocd/applications/deploykf-dependencies/kyverno.yaml
+++ b/generator/templates/argocd/applications/deploykf-dependencies/kyverno.yaml
@@ -4,6 +4,10 @@ kind: Application
 metadata:
   name: dkf-dep--kyverno
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## applications in 'deploykf-dependencies' come first
+    ## NOTE: in this group, each application has a separate wave to avoid conflicts due to webhooks
+    argocd.argoproj.io/sync-wave: "12"
   labels:
     app.kubernetes.io/name: kyverno
     app.kubernetes.io/component: deploykf-dependencies

--- a/generator/templates/argocd/applications/deploykf-opt/deploykf-minio.yaml
+++ b/generator/templates/argocd/applications/deploykf-opt/deploykf-minio.yaml
@@ -4,6 +4,9 @@ kind: Application
 metadata:
   name: dkf-opt--deploykf-minio
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## applications in 'deploykf-opt' come after 'deploykf-core'
+    argocd.argoproj.io/sync-wave: "30"
   labels:
     app.kubernetes.io/name: deploykf-minio
     app.kubernetes.io/component: deploykf-opt

--- a/generator/templates/argocd/applications/deploykf-opt/deploykf-mysql.yaml
+++ b/generator/templates/argocd/applications/deploykf-opt/deploykf-mysql.yaml
@@ -4,6 +4,9 @@ kind: Application
 metadata:
   name: dkf-opt--deploykf-mysql
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## applications in 'deploykf-opt' come after 'deploykf-core'
+    argocd.argoproj.io/sync-wave: "30"
   labels:
     app.kubernetes.io/name: deploykf-mysql
     app.kubernetes.io/component: deploykf-opt

--- a/generator/templates/argocd/applications/kubeflow-dependencies/kubeflow-argo-workflows.yaml
+++ b/generator/templates/argocd/applications/kubeflow-dependencies/kubeflow-argo-workflows.yaml
@@ -4,6 +4,9 @@ kind: Application
 metadata:
   name: kf-dep--argo-workflows
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## applications in 'kubeflow-dependencies' come after 'deploykf-tools'
+    argocd.argoproj.io/sync-wave: "50"
   labels:
     app.kubernetes.io/name: kubeflow-argo-workflows
     app.kubernetes.io/component: kubeflow-dependencies

--- a/generator/templates/argocd/applications/kubeflow-tools/katib.yaml
+++ b/generator/templates/argocd/applications/kubeflow-tools/katib.yaml
@@ -4,6 +4,9 @@ kind: Application
 metadata:
   name: kf-tools--katib
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## applications in 'kubeflow-tools' come after 'kubeflow-dependencies'
+    argocd.argoproj.io/sync-wave: "60"
   labels:
     app.kubernetes.io/name: katib
     app.kubernetes.io/component: kubeflow-tools

--- a/generator/templates/argocd/applications/kubeflow-tools/notebooks--jupyter-web-app.yaml
+++ b/generator/templates/argocd/applications/kubeflow-tools/notebooks--jupyter-web-app.yaml
@@ -4,6 +4,9 @@ kind: Application
 metadata:
   name: kf-tools--notebooks--jupyter-web-app
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## applications in 'kubeflow-tools' come after 'kubeflow-dependencies'
+    argocd.argoproj.io/sync-wave: "60"
   labels:
     app.kubernetes.io/name: jupyter-web-app
     app.kubernetes.io/component: kubeflow-tools

--- a/generator/templates/argocd/applications/kubeflow-tools/notebooks--notebook-controller.yaml
+++ b/generator/templates/argocd/applications/kubeflow-tools/notebooks--notebook-controller.yaml
@@ -4,6 +4,9 @@ kind: Application
 metadata:
   name: kf-tools--notebooks--notebook-controller
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## applications in 'kubeflow-tools' come after 'kubeflow-dependencies'
+    argocd.argoproj.io/sync-wave: "60"
   labels:
     app.kubernetes.io/name: notebook-controller
     app.kubernetes.io/component: kubeflow-tools

--- a/generator/templates/argocd/applications/kubeflow-tools/pipelines.yaml
+++ b/generator/templates/argocd/applications/kubeflow-tools/pipelines.yaml
@@ -4,6 +4,9 @@ kind: Application
 metadata:
   name: kf-tools--pipelines
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## applications in 'kubeflow-tools' come after 'kubeflow-dependencies'
+    argocd.argoproj.io/sync-wave: "60"
   labels:
     app.kubernetes.io/name: pipelines
     app.kubernetes.io/component: kubeflow-tools

--- a/generator/templates/argocd/applications/kubeflow-tools/poddefaults-webhook.yaml
+++ b/generator/templates/argocd/applications/kubeflow-tools/poddefaults-webhook.yaml
@@ -4,6 +4,9 @@ kind: Application
 metadata:
   name: kf-tools--poddefaults-webhook
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## applications in 'kubeflow-tools' come after 'kubeflow-dependencies'
+    argocd.argoproj.io/sync-wave: "60"
   labels:
     app.kubernetes.io/name: poddefaults-webhook
     app.kubernetes.io/component: kubeflow-tools

--- a/generator/templates/argocd/applications/kubeflow-tools/tensorboards--tensorboard-controller.yaml
+++ b/generator/templates/argocd/applications/kubeflow-tools/tensorboards--tensorboard-controller.yaml
@@ -4,6 +4,9 @@ kind: Application
 metadata:
   name: kf-tools--tensorboards--tensorboard-controller
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## applications in 'kubeflow-tools' come after 'kubeflow-dependencies'
+    argocd.argoproj.io/sync-wave: "60"
   labels:
     app.kubernetes.io/name: tensorboard-controller
     app.kubernetes.io/component: kubeflow-tools

--- a/generator/templates/argocd/applications/kubeflow-tools/tensorboards--tensorboards-web-app.yaml
+++ b/generator/templates/argocd/applications/kubeflow-tools/tensorboards--tensorboards-web-app.yaml
@@ -4,6 +4,9 @@ kind: Application
 metadata:
   name: kf-tools--tensorboards--tensorboards-web-app
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## applications in 'kubeflow-tools' come after 'kubeflow-dependencies'
+    argocd.argoproj.io/sync-wave: "60"
   labels:
     app.kubernetes.io/name: tensorboards-web-app
     app.kubernetes.io/component: kubeflow-tools

--- a/generator/templates/argocd/applications/kubeflow-tools/training-operator.yaml
+++ b/generator/templates/argocd/applications/kubeflow-tools/training-operator.yaml
@@ -4,6 +4,9 @@ kind: Application
 metadata:
   name: kf-tools--training-operator
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## applications in 'kubeflow-tools' come after 'kubeflow-dependencies'
+    argocd.argoproj.io/sync-wave: "60"
   labels:
     app.kubernetes.io/name: training-operator
     app.kubernetes.io/component: kubeflow-tools

--- a/generator/templates/argocd/applications/kubeflow-tools/volumes--volumes-web-app.yaml
+++ b/generator/templates/argocd/applications/kubeflow-tools/volumes--volumes-web-app.yaml
@@ -4,6 +4,9 @@ kind: Application
 metadata:
   name: kf-tools--volumes--volumes-web-app
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## applications in 'kubeflow-tools' come after 'kubeflow-dependencies'
+    argocd.argoproj.io/sync-wave: "60"
   labels:
     app.kubernetes.io/name: volumes-web-app
     app.kubernetes.io/component: kubeflow-tools

--- a/generator/templates/argocd/applications/namespaces.yaml
+++ b/generator/templates/argocd/applications/namespaces.yaml
@@ -4,6 +4,9 @@ kind: Application
 metadata:
   name: deploykf-namespaces
   namespace: {{< .Values.argocd.namespace | quote >}}
+  annotations:
+    ## we must sync namespaces before all other applications
+    argocd.argoproj.io/sync-wave: "-1000"
   labels:
     app.kubernetes.io/name: deploykf-namespaces
     app.kubernetes.io/part-of: {{< print .Values.argocd.appNamePrefix "deploykf" | quote >}}


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

resolves https://github.com/deployKF/deployKF/issues/24

This PR adds ArgoCD sync waves to the Applications. While this only affects the order that the apps are synced to the cluster (not the syncing of the manifests they contain), it does affect the order ArgoCD will delete them in, if the user deletes the `deploykf-app-of-apps`. Upon deletion, ArgoCD will delete resources in reverse sync-wave order.

We have ordered the waves in this PR so that things should be deleted BEFORE the things which they depend on.
The most important one is `dkf-core--deploykf-profiles-generator` must be deleted BEFORE `dkf-core--deploykf-dashboard` (the profiles have a finalizer that the profile controller must remove).

Also, adding these sync waves has allowed the creation of a script to automatically sync (at deployment time), because a script can look at the relative waves and sync them in the correct order.