### PR TITLE
fix: resolve profile generator race condition

### DIFF
--- a/generator/templates/argocd/applications/deploykf-core/deploykf-profiles-generator.yaml
+++ b/generator/templates/argocd/applications/deploykf-core/deploykf-profiles-generator.yaml
@@ -33,6 +33,14 @@ spec:
     server: {{< .Values.argocd.destination.server | quote >}}
     {{<- end >}}
     namespace: kubeflow
+  syncPolicy:
+    ## retry is needed because the profile controller takes a few seconds to provision the namespaces
+    retry:
+      limit: 4
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
   ignoreDifferences:
     ## `rules` are aggregated when `aggregationRule.clusterRoleSelectors` is set
     - group: rbac.authorization.k8s.io


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

This PR sets a default ArgoCD retry on the `dkf-core--deploykf-profiles-generator` application.

This is needed because the profile generator creates resources in profile namespaces, but the profile controller takes a few seconds to provision the namespaces, causing failure on the first sync of a new profile.