### PR TITLE
fix: resolve race conditions with cloned secrets

### DIFF
--- a/generator/templates/manifests/kubeflow-dependencies/kubeflow-argo-workflows/templates/ClusterPolicy-clone-bucket-secret.yaml
+++ b/generator/templates/manifests/kubeflow-dependencies/kubeflow-argo-workflows/templates/ClusterPolicy-clone-bucket-secret.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     ## kyverno policies with "generate" cant be updated: https://github.com/kyverno/kyverno/issues/7718
     argocd.argoproj.io/sync-options: Replace=true
+    ## kyverno policies that clone resources must be synced before other resources
+    argocd.argoproj.io/sync-wave: "-1"
   labels:
     helm.sh/chart: {{ include "kubeflow-argo-workflows.labels.chart" . }}
     app.kubernetes.io/name: {{ include "kubeflow-argo-workflows.labels.name" . }}

--- a/generator/templates/manifests/kubeflow-tools/katib/resources/clone-mysql-secret-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/katib/resources/clone-mysql-secret-clusterpolicy.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     ## kyverno policies with "generate" cant be updated: https://github.com/kyverno/kyverno/issues/7718
     argocd.argoproj.io/sync-options: Replace=true
+    ## kyverno policies that clone resources must be synced before other resources
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   generateExisting: true
   rules:

--- a/generator/templates/manifests/kubeflow-tools/pipelines/resources/clone-bucket-secret-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/resources/clone-bucket-secret-clusterpolicy.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     ## kyverno policies with "generate" cant be updated: https://github.com/kyverno/kyverno/issues/7718
     argocd.argoproj.io/sync-options: Replace=true
+    ## kyverno policies that clone resources must be synced before other resources
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   generateExisting: true
   rules:

--- a/generator/templates/manifests/kubeflow-tools/pipelines/resources/clone-mysql-secret-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/resources/clone-mysql-secret-clusterpolicy.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     ## kyverno policies with "generate" cant be updated: https://github.com/kyverno/kyverno/issues/7718
     argocd.argoproj.io/sync-options: Replace=true
+    ## kyverno policies that clone resources must be synced before other resources
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   generateExisting: true
   rules:


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

This PR addresses race conditions between cloned Secrets and the Pods which mount them.

This is achieved by setting the  `argocd.argoproj.io/sync-wave` to `-1` on the Kyverno `ClusterPolicies` responsible for  cloning these secrets, ensuring they are always synced before the rest of their apps.