### PR TITLE
fix: app-of-apps should always target argocd cluster

### DIFF
--- a/generator/templates/app-of-apps.yaml
+++ b/generator/templates/app-of-apps.yaml
@@ -20,10 +20,7 @@ spec:
     targetRevision: {{< .Values.argocd.source.repo.revision | quote >}}
     path: {{< path.Join .Values.argocd.source.repo.path "argocd" | quote >}}
   destination:
-    {{<- if .Values.argocd.destination.name >}}
-    name: {{< .Values.argocd.destination.name | quote >}}
-    {{<- else >}}
-    server: {{< .Values.argocd.destination.server | quote >}}
-    {{<- end >}}
+    ## NOTE: even if the internal apps target a remote cluster, the apps themselves should be in the Argo CD cluster
+    server: "https://kubernetes.default.svc"
     namespace: {{< .Values.argocd.namespace | quote >}}
 {{<- end >}}


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

Currently when using "Manifests Repo" Mode, the generated `deploykf-app-of-apps` targets the `argocd.destination`, which is not correct. Even if the internal apps target a remote cluster, the apps themselves should be in the Argo CD cluster.