### PR TITLE
docs: add reference `sync_argocd_apps.sh` script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,48 @@
+# deployKF Reference Scripts
+
+This directory contains helpful scripts for working with deployKF.
+
+## [`sync_argocd_apps.sh`](./sync_argocd_apps.sh)
+
+This script automatically syncs the ArgoCD applications that make up deployKF.
+
+### Requirements:
+
+- The `kubectl` CLI is installed ([install guide](https://kubernetes.io/docs/tasks/tools/install-kubectl/))
+- The `argocd` CLI is installed ([install guide](https://argo-cd.readthedocs.io/en/stable/cli_installation/))
+- The `jq` CLI is installed ([install guide](https://stedolan.github.io/jq/download/))
+- A deployKF "app of apps" has been applied to the cluster ([example for plugin mode](../argocd-plugin/README.md#plugin-usage))
+- The deployKF version being used is `0.1.2` or later ([release notes](https://www.deploykf.org/releases/changelog-deploykf/))
+
+### Behavior:
+
+By default, the script will:
+
+- Use `kubectl` port-forwarding to connect to the ArgoCD API server.
+- Assume ArgoCD is installed to the `argocd` Namespace.
+- Assume the ArgoCD `admin` password can be found in `Secret/argocd-initial-admin-secret`.
+- Prompt for confirmation before pruning (deleting) resources during a sync (defaults to `no` after 30 seconds).
+
+### Usage:
+
+To run the script with the default settings:
+
+```bash
+# clone the deploykf repository (at the 'main' branch)
+git clone -b main https://github.com/deployKF/deployKF.git ./deploykf
+
+# change to the argocd-plugin directory
+cd ./deploykf/scripts
+
+# ensure the script is executable
+chmod +x ./sync_argocd_apps.sh
+
+# sync all deployKF ArgoCD applications
+./sync_argocd_apps.sh
+```
+
+> __NOTE:__
+>
+> - The script can take around 5-10 minutes to run on first install.
+> - If the script fails or is interrupted, you can safely re-run it, and it will pick up where it left off.
+> - There are a number of configuration variables at the top of the script which change the default behavior.

--- a/scripts/sync_argocd_apps.sh
+++ b/scripts/sync_argocd_apps.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+#
+# This script automatically syncs the ArgoCD applications that make up deployKF.
+#
+
+#######################################
+# CONFIGURATION
+#######################################
+
+# the namespace where argocd is installed
+ARGOCD_NAMESPACE="argocd"
+
+# the argocd server URL
+#  - If empty, port-forwarding will be used to connect to the argocd server.
+ARGOCD_SERVER_URL=""
+
+# credentials for argocd
+#  - If password is empty, and username is "admin", the 'argocd-initial-admin-secret' will be read from the cluster.
+#    This will NOT work if you have changed the ArgoCD admin password.
+ARGOCD_USERNAME="admin"
+ARGOCD_PASSWORD=""
+
+# how to handle resources that require pruning
+#  - 'always': prune resources without prompting (DANGER: this can delete resources that are still in use)
+#  - 'prompt': ask the user if they want to prune resources (defaults to 'no' after timeout)
+#  - 'skip': continue silently without pruning
+ARGOCD_PRUNE_MODE="prompt"
+ARGOCD_PRUNE_PROMPT_SECONDS="30"
+
+# timeouts for argocd commands
+ARGOCD_SYNC_TIMEOUT_SECONDS="600"
+ARGOCD_WAIT_TIMEOUT_SECONDS="300"
+
+#######################################
+# COLORS
+#######################################
+
+# if color is supported, use it
+if [[ -t 1 ]] && [[ -n "$(command -v tput)" ]] && [[ $(tput colors) -ge 8 ]]; then
+  COLOR_RED=$(tput setaf 1)
+  COLOR_GREEN=$(tput setaf 2)
+  COLOR_YELLOW=$(tput setaf 3)
+  COLOR_BLUE=$(tput setaf 4)
+  COLOR_MAGENTA=$(tput setaf 5)
+  BOLD=$(tput bold)
+  NC=$(tput sgr0)
+else
+  COLOR_RED=""
+  COLOR_GREEN=""
+  COLOR_YELLOW=""
+  COLOR_BLUE=""
+  COLOR_MAGENTA=""
+  BOLD=""
+  NC=""
+fi
+
+function echo_red() {
+  echo "${COLOR_RED}${BOLD}$1${NC}"
+}
+
+function echo_green() {
+  echo "${COLOR_GREEN}${BOLD}$1${NC}"
+}
+
+function echo_yellow() {
+  echo "${COLOR_YELLOW}${BOLD}$1${NC}"
+}
+
+function echo_blue() {
+  echo "${COLOR_BLUE}${BOLD}$1${NC}"
+}
+
+function echo_magenta() {
+  echo "${COLOR_MAGENTA}${BOLD}$1${NC}"
+}
+
+#######################################
+# FUNCTIONS
+#######################################
+
+# authenticate to argocd
+function argocd_login() {
+  local _argocd_server_url="$1"
+  local _argocd_namespace="$2"
+  local _argocd_username="$3"
+  local _argocd_password="$4"
+
+  # if "admin" is the username and no password is provided, get the password from the cluster
+  if [[ "$_argocd_username" == "admin" && -z "$_argocd_password" ]]; then
+    echo ""
+    echo_blue "=========================================================================================="
+    echo_blue "Getting admin password from 'Secret/argocd-initial-admin-secret'..."
+    echo_blue "=========================================================================================="
+    _argocd_password=$(
+      kubectl -n "$_argocd_namespace" get secret "argocd-initial-admin-secret" -o jsonpath="{.data.password}" \
+      | base64 -d
+    )
+    echo_green ">>> DONE"
+  fi
+
+  # log in to argocd
+  echo ""
+  echo_blue "=========================================================================================="
+  echo_blue "Logging in to ArgoCD..."
+  echo_blue "=========================================================================================="
+  if [[ -n "$_argocd_server_url" ]]; then
+    argocd login "$_argocd_server_url" --username "$_argocd_username" --password "$_argocd_password"
+  else
+    # NOTE: we must export ARGOCD_OPTS for all the argocd commands to see it
+    export ARGOCD_OPTS="--port-forward --port-forward-namespace '$_argocd_namespace'"
+    argocd login --username "$_argocd_username" --password "$_argocd_password"
+  fi
+  echo_green ">>> DONE"
+}
+
+# syncs a list of argocd applications
+#  - if pruning is disabled, the user may be prompted to retry with pruning enabled
+function sync_argocd_apps() {
+  local _enable_prune="$1"
+  local _prompt_for_prune="$2"
+  local _app_names=("${@:3}")
+
+  echo ""
+  echo_blue "=========================================================================================="
+  echo_blue "Syncing applications (timeout: ${ARGOCD_SYNC_TIMEOUT_SECONDS}s, prune: $_enable_prune)..."
+  local _app_name
+  for _app_name in "${_app_names[@]}"; do
+    echo_blue " - $_app_name"
+  done
+  echo_blue "=========================================================================================="
+
+  # build sync command arguments
+  local -a _sync_args=()
+  _sync_args+=(
+    "--timeout" "$ARGOCD_SYNC_TIMEOUT_SECONDS"
+  )
+  if [[ "$_enable_prune" == "true" ]]; then
+    _sync_args+=("--prune")
+  fi
+
+  # run the sync command
+  #  - captures STDERR
+  #  - prints both STDERR and STDOUT to the console
+  local _cmd_stderr
+  local _cmd_exit_code
+  exec 3>&1
+  set +e
+  _cmd_stderr=$(argocd app sync "${_app_names[@]}" "${_sync_args[@]}" 2>&1 >&3 | tee /dev/stderr)
+  _cmd_exit_code=$?
+  set -e
+  exec 3>&-
+
+  # if the command failed, handle the error
+  if [[ $_cmd_exit_code -ne 0 ]]; then
+
+    # handle pruning errors
+    if [[ "$_cmd_stderr" =~ "resources require pruning" ]]; then
+      echo_yellow ">>> WARNING: There are resources that need to be PRUNED"
+      if [[ "$_prompt_for_prune" == "true" ]]; then
+        echo ""
+        echo_magenta "Do you want to sync again with PRUNING enabled?"
+        echo ""
+        echo_red "Pruning DELETES resources that are no longer part of the application."
+        echo_red "Check that resources above with '(requires pruning)' can be safely deleted."
+        echo ""
+        echo_yellow "If you are unsure, respond with 'no' or press ENTER to continue without pruning."
+        echo ""
+        while true; do
+            echo "${COLOR_MAGENTA}${BOLD}OPTIONS:${NC} ${COLOR_RED}${BOLD}yes${NC}, ${COLOR_GREEN}${BOLD}no${NC} (default)"
+            echo "${COLOR_MAGENTA}${BOLD}TIMEOUT:${NC} ${ARGOCD_PRUNE_PROMPT_SECONDS} seconds"
+            read -r -t "$ARGOCD_PRUNE_PROMPT_SECONDS" -p "${COLOR_MAGENTA}${BOLD}RESPONSE:${NC} " response || echo "<no response, continuing without pruning>"
+            case "$response" in
+                "YES" | "yes" | "Y" | "y" )
+                  echo_yellow ">>> Syncing again with pruning enabled..."
+                  sync_argocd_apps "true" "false" "${_app_names[@]}"
+                  break
+                  ;;
+                "NO" | "no" | "N" | "n" | "" )
+                  echo_yellow ">>> Continuing without pruning..."
+                  break
+                  ;;
+                * )
+                  echo ""
+                  ;;
+            esac
+        done
+      else
+        echo_yellow ">>> Continuing without pruning..."
+      fi
+
+    # otherwise, exit with the error code
+    else
+      echo_red ">>> ERROR: Sync Failed"
+      exit $_cmd_exit_code
+    fi
+  else
+    echo_green ">>> Sync Succeeded"
+  fi
+}
+
+# wait for an argocd application to be healthy
+function argocd_app_wait() {
+  local _app_names=("$@")
+
+  echo ""
+  echo_blue "=========================================================================================="
+  echo_blue "Waiting ${ARGOCD_WAIT_TIMEOUT_SECONDS}s for applications to be healthy..."
+  local _app_name
+  for _app_name in "${_app_names[@]}"; do
+    echo_blue " - $_app_name"
+  done
+  echo_blue "=========================================================================================="
+
+  # wait for the application to be healthy
+  argocd app wait "${_app_names[@]}" --health --timeout "$ARGOCD_WAIT_TIMEOUT_SECONDS"
+  echo_green ">>> DONE"
+}
+
+# sync argocd applications that match a label selector
+#  - applications are synced in parallel groups, based on their "sync wave"
+#  - after each group is synced, we wait for all applications in that group to be healthy
+function sync_argocd() {
+  local _app_namespace="$1"
+  local _app_selector="$2"
+
+  echo ""
+  echo_blue "=========================================================================================="
+  echo_blue "Getting status of '${_app_selector}' applications..."
+  echo_blue "=========================================================================================="
+
+  # this associative array has the "sync wave numbers" as the keys, and SPACE-separated "app names" as the values
+  local -A _sync_waves=()
+
+  # this associative array has "app names" as keys, and "sync status" as values
+  local -A _app_sync_statuses=()
+
+  # build an array of applications to sync
+  local _app_name
+  local _app_json
+  local _app_sync_wave
+  local _app_sync_status
+  local _app_operation_state
+  local _app_operation_state_phase
+  for _app_name in $(argocd app list -l "$_app_selector" -N "$_app_namespace" -o "name"); do
+
+    # get the application as JSON (and refresh at same time)
+    _app_json=$(argocd app get "$_app_name" -o json --refresh)
+
+    # extract the sync-wave from the application (default: 0)
+    _app_sync_wave=$(echo "$_app_json" | jq -r '.metadata.annotations."argocd.argoproj.io/sync-wave" // "0"')
+
+    # extract the sync status from the application (default: "Unknown")
+    # SPEC: https://github.com/argoproj/argo-cd/blob/v2.7.14/pkg/apis/application/v1alpha1/types.go#L1332-L1343
+    _app_sync_status=$(echo "$_app_json" | jq -r '.status.sync.status // "Unknown"')
+
+    # extract the operation state from the application (default: empty)
+    # SPEC: https://github.com/argoproj/argo-cd/blob/v2.7.14/pkg/apis/application/v1alpha1/types.go#L1011-L1026
+    _app_operation_state=$(echo "$_app_json" | jq -r '.status.operationState // empty')
+
+    # extract the operation state phase from the application (default: "Succeeded")
+    # SPEC: https://github.com/argoproj/gitops-engine/blob/v0.7.3/pkg/sync/common/types.go#L50-L58
+    _app_operation_state_phase=$(echo "$_app_operation_state" | jq -r '.phase // "Succeeded"')
+
+    # if the sync status is "Unknown", fail
+    if [[ "$_app_sync_status" == "Unknown" ]]; then
+      echo_red ">>> ERROR: '$_app_name' has a sync status of 'Unknown'"
+      exit 1
+    fi
+
+    # if the operation state phase is "Running" or "Terminating", fail
+    if [[ "$_app_operation_state_phase" == "Running" || "$_app_operation_state_phase" == "Terminating" ]]; then
+      echo_red ">>> ERROR: '$_app_name' has an operation in progress (phase: '$_app_operation_state_phase')"
+      exit 1
+    fi
+
+    # add the application to the sync status array
+    _app_sync_statuses[$_app_name]="$_app_sync_status"
+
+    # add the application to the sync wave array
+    if [[ -v _sync_waves["$_app_sync_wave"] ]]; then
+      _sync_waves[$_app_sync_wave]+=" $_app_name"
+    else
+      _sync_waves[$_app_sync_wave]="$_app_name"
+    fi
+  done
+
+  # get the sync waves in ascending order
+  local _sync_wave
+  local -a _sync_waves_sorted=()
+  for _sync_wave in $(echo "${!_sync_waves[@]}" | tr ' ' '\n' | sort -n); do
+    _sync_waves_sorted+=("$_sync_wave")
+  done
+
+  # print the sync waves and their applications
+  echo_yellow ">>> Found ${#_app_sync_statuses[@]} applications in ${#_sync_waves_sorted[@]} sync waves."
+  local _app_name
+  local _sync_wave
+  local _sync_wave_apps
+  for _sync_wave in "${_sync_waves_sorted[@]}"; do
+    IFS=' ' read -r -a _sync_wave_apps <<< "${_sync_waves[$_sync_wave]}"
+    echo ""
+    echo_yellow ">>> Sync wave $_sync_wave:"
+    for _app_name in "${_sync_wave_apps[@]}"; do
+      echo_yellow ">>>  - $_app_name (status: ${_app_sync_statuses[$_app_name]})"
+    done
+  done
+
+  # sync out-of-sync applications in each sync wave
+  local _app_name
+  local _sync_wave
+  local _sync_wave_apps
+  for _sync_wave in "${_sync_waves_sorted[@]}"; do
+    IFS=' ' read -r -a _sync_wave_apps <<< "${_sync_waves[$_sync_wave]}"
+
+    # build an array of out-of-sync applications in this sync wave
+    local -a _out_of_sync_apps=()
+    for _app_name in "${_sync_wave_apps[@]}"; do
+      if [[ "${_app_sync_statuses[$_app_name]}" != "Synced" ]]; then
+        _out_of_sync_apps+=("$_app_name")
+      fi
+    done
+
+    # sync the out-of-sync applications
+    if [[ -n "${_out_of_sync_apps[*]}" ]]; then
+      case "$ARGOCD_PRUNE_MODE" in
+        "always")
+          sync_argocd_apps "true" "false" "${_out_of_sync_apps[@]}"
+          ;;
+        "prompt")
+          sync_argocd_apps "false" "true" "${_out_of_sync_apps[@]}"
+          ;;
+        "skip")
+          sync_argocd_apps "false" "false" "${_out_of_sync_apps[@]}"
+          ;;
+        *)
+          echo_red ">>> ERROR: Invalid ARGOCD_PRUNE_MODE: '$ARGOCD_PRUNE_MODE'"
+          exit 1
+          ;;
+      esac
+    fi
+
+    # wait for ALL applications in this sync wave to be healthy
+    # NOTE: this includes applications that were already in-sync before the sync command
+    if [[ -n "${_sync_wave_apps[*]}" ]]; then
+      argocd_app_wait "${_sync_wave_apps[@]}"
+    fi
+  done
+}
+
+#######################################
+# MAIN
+#######################################
+
+# authenticate to argocd
+argocd_login "$ARGOCD_SERVER_URL" "$ARGOCD_NAMESPACE" "$ARGOCD_USERNAME" "$ARGOCD_PASSWORD"
+
+# sync the "deploykf-app-of-apps" application
+sync_argocd "$ARGOCD_NAMESPACE" "app.kubernetes.io/name=deploykf-app-of-apps"
+
+# sync the "deploykf-namespaces" application
+sync_argocd "$ARGOCD_NAMESPACE" "app.kubernetes.io/name=deploykf-namespaces"
+
+# sync all applications in the "deploykf-dependencies" group
+sync_argocd "$ARGOCD_NAMESPACE" "app.kubernetes.io/component=deploykf-dependencies"
+
+# sync all applications in the "deploykf-core" group
+sync_argocd "$ARGOCD_NAMESPACE" "app.kubernetes.io/component=deploykf-core"
+
+# sync all applications in the "deploykf-opt" group
+sync_argocd "$ARGOCD_NAMESPACE" "app.kubernetes.io/component=deploykf-opt"
+
+# sync all applications in the "deploykf-tools" group
+sync_argocd "$ARGOCD_NAMESPACE" "app.kubernetes.io/component=deploykf-tools"
+
+# sync all applications in the "kubeflow-dependencies" group
+sync_argocd "$ARGOCD_NAMESPACE" "app.kubernetes.io/component=kubeflow-dependencies"
+
+# sync all applications in the "kubeflow-tools" group
+sync_argocd "$ARGOCD_NAMESPACE" "app.kubernetes.io/component=kubeflow-tools"


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR adds a new  `sync_argocd_apps.sh` script under the `scripts/` folder of the repo.

The purpose of this script is to automate the process of syncing all the ArgoCD applications that make up deployKF.

It is designed to follow the correct ordering laid out by the sync waves added in https://github.com/deployKF/deployKF/pull/32.

The script is NOT intended to be used with deployKF versions older than `0.1.2`.