### PR TITLE
docs: add requirement checks to argocd sync script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,6 +8,7 @@ This script automatically syncs the ArgoCD applications that make up deployKF.
 
 ### Requirements:
 
+- Bash `4.2` or later _(macOS has `3.2` by default, update with `brew install bash`)_
 - The `kubectl` CLI is installed ([install guide](https://kubernetes.io/docs/tasks/tools/install-kubectl/))
 - The `argocd` CLI is installed ([install guide](https://argo-cd.readthedocs.io/en/stable/cli_installation/))
 - The `jq` CLI is installed ([install guide](https://stedolan.github.io/jq/download/))

--- a/scripts/sync_argocd_apps.sh
+++ b/scripts/sync_argocd_apps.sh
@@ -35,6 +35,34 @@ ARGOCD_SYNC_TIMEOUT_SECONDS="600"
 ARGOCD_WAIT_TIMEOUT_SECONDS="300"
 
 #######################################
+# REQUIREMENTS
+#######################################
+
+# ensure bash version 4.2+
+if [[ ${BASH_VERSINFO[0]} -lt 4 || (${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -lt 2) ]]; then
+  echo ">>> ERROR: Bash version 4.2+ is required to run this script, current version: '${BASH_VERSION}'"
+  exit 1
+fi
+
+# ensure 'argocd' is installed
+if [[ -z "$(command -v argocd)" ]]; then
+  echo ">>> ERROR: 'argocd' must be installed to run this script"
+  exit 1
+fi
+
+# ensure 'jq' is installed
+if [[ -z "$(command -v jq)" ]]; then
+  echo ">>> ERROR: 'jq' must be installed to run this script"
+  exit 1
+fi
+
+# ensure 'kubectl' is installed
+if [[ -z "$(command -v kubectl)" ]]; then
+  echo ">>> ERROR: 'kubectl' must be installed to run this script"
+  exit 1
+fi
+
+#######################################
 # COLORS
 #######################################
 


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR adds requirement checks to the `sync_argocd_apps.sh` script so we can prevent confusing errors when using an incompatible bash version, or when other dependencies are missing.

Apparently macOS ships with a version of bash from 2007 by default (version 3.2), which is not new enough to run the `sync_argocd_apps.sh` script.
