### PR TITLE
feat: update oauth2-proxy to 7.5.1

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -364,7 +364,7 @@ deploykf_core:
 
       oauth2Proxy:
         repository: quay.io/oauth2-proxy/oauth2-proxy
-        tag: v7.4.0
+        tag: v7.5.1
         pullPolicy: IfNotPresent
 
       kubectl:

--- a/generator/templates/manifests/deploykf-core/deploykf-auth/templates/oauth2-proxy/Deployment.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-auth/templates/oauth2-proxy/Deployment.yaml
@@ -81,7 +81,7 @@ spec:
               port: http
           readinessProbe:
             httpGet:
-              path: /ping
+              path: /ready
               port: http
           volumeMounts:
             - name: oauth2-proxy-config


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR updates the default version of `oauth2-proxy` to `7.5.1`.

__WARNING:__ we make use of the new `/ready` HTTP path that was added in `7.5.0`, so we no longer support `7.4` versions of `oauth2-proxy`.