### PR TITLE
feat: browser-based KFP SDK auth

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -468,6 +468,13 @@ deploykf_core:
             existingSecretKey: "client_secret"
             generateSecret: false
 
+        ## OpenID client for Kubeflow Pipelines SDK
+        ##  - note, this client is used on end-user machines, so it does not have a client secret
+        ##
+        kubeflowPipelinesSDK:
+          enabled: true
+          clientId: "kubeflow-pipelines-sdk"
+
     ## oauth2-proxy configs
     ##
     oauth2Proxy:

--- a/generator/templates/manifests/deploykf-core/deploykf-auth/templates/dex/Secret-config.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-auth/templates/dex/Secret-config.yaml
@@ -116,6 +116,16 @@ staticClients:
     {{- end }}
   {{- end }}
 
+  {{ if .Values.dex.clients.kubeflowPipelinesSDK.enabled -}}
+  ## the OpenID client for "Kubeflow Pipelines SDK"
+  - name: "Kubeflow Pipelines SDK"
+    id: {{ .Values.dex.clients.kubeflowPipelinesSDK.clientId | quote }}
+    ## NOTE: this client is used on end-user machines, so it does not have a client secret
+    public: true
+    redirectURIs:
+      - "urn:ietf:wg:oauth:2.0:oob"
+  {{- end }}
+
 ## configs for upstream identity providers for authenticating users
 {{- if .Values.dex.connectors }}
 connectors:

--- a/generator/templates/manifests/deploykf-core/deploykf-auth/templates/oauth2-proxy/Secret-config.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-auth/templates/oauth2-proxy/Secret-config.yaml
@@ -82,8 +82,22 @@ skip_provider_button = true
 ## oauth2-proxy does not verify nonce claim by default
 insecure_oidc_skip_nonce = false
 
-# use PKCE code challenges
+## use PKCE code challenges
 code_challenge_method = "S256"
+
+################
+## bearer token
+################
+
+## allow bearer tokens to be used for authentication
+skip_jwt_bearer_tokens = true
+
+## trust audience claims used by other known dex clients
+oidc_extra_audiences = [
+  {{- if .Values.dex.clients.kubeflowPipelinesSDK.enabled }}
+  {{ .Values.dex.clients.kubeflowPipelinesSDK.clientId | quote }}
+  {{- end }}
+]
 
 ################
 ## cookie

--- a/generator/templates/manifests/deploykf-core/deploykf-auth/values.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-auth/values.yaml
@@ -137,6 +137,12 @@ dex:
         {{< fail "`deploykf_core.deploykf_auth.dex.clients.argoServer.clientSecret.existingSecret` must be non-empty if `deploykf_core.deploykf_auth.dex.clients.argoServer.clientSecret.generateSecret` is true" >}}
         {{<- end >}}
 
+    ## OpenID client for Kubeflow Pipelines SDK
+    ##
+    kubeflowPipelinesSDK:
+      enabled: {{< and (.Values.kubeflow_tools.pipelines.enabled | conv.ToBool) (.Values.deploykf_core.deploykf_auth.dex.clients.kubeflowPipelinesSDK.enabled | conv.ToBool) >}}
+      clientId: {{< .Values.deploykf_core.deploykf_auth.dex.clients.kubeflowPipelinesSDK.clientId | quote >}}
+
   ## dex static passwords
   ##
   staticPasswords: {{< .Values.deploykf_core.deploykf_auth.dex.staticPasswords | toJSON >}}

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/EnvoyFilter-ext-authz-disable.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/EnvoyFilter-ext-authz-disable.yaml
@@ -36,15 +36,23 @@ spec:
           typed_per_filter_config:
             ## the ExtAuthz filter is called "envoy.filters.http.ext_authz"
             envoy.filters.http.ext_authz:
-              ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-extauthzperroute
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-extauthzperroute
               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
 
               ## if true, disables the ExtAuthz filter on this HTTP_ROUTE
               disabled: true
 
+            ## the JwtAuthn filter is called "envoy.filters.http.jwt_authn"
+            envoy.filters.http.jwt_authn:
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/jwt_authn/v3/config.proto#extensions-filters-http-jwt-authn-v3-perrouteconfig
+              "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+
+              ## if true, disables the JwtAuthn filter on this HTTP_ROUTE
+              disabled: true
+
             ## the Lua filter that sets USERID_HEADER is called "envoy.filters.http.lua.set_userid_header"
             envoy.filters.http.lua.set_userid_header:
-              ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/http/lua/v3/lua.proto#extensions-filters-http-lua-v3-luaperroute
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/lua/v3/lua.proto#extensions-filters-http-lua-v3-luaperroute
               "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
 
               ## if true, disables the Lua filter on this HTTP_ROUTE
@@ -68,15 +76,23 @@ spec:
           typed_per_filter_config:
             ## the ExtAuthz filter is called "envoy.filters.http.ext_authz"
             envoy.filters.http.ext_authz:
-              ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-extauthzperroute
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-extauthzperroute
               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
 
               ## if true, disables the ExtAuthz filter on this HTTP_ROUTE
               disabled: true
 
+            ## the JwtAuthn filter is called "envoy.filters.http.jwt_authn"
+            envoy.filters.http.jwt_authn:
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/jwt_authn/v3/config.proto#extensions-filters-http-jwt-authn-v3-perrouteconfig
+              "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+
+              ## if true, disables the JwtAuthn filter on this HTTP_ROUTE
+              disabled: true
+
             ## the Lua filter that sets USERID_HEADER is called "envoy.filters.http.lua.set_userid_header"
             envoy.filters.http.lua.set_userid_header:
-              ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/http/lua/v3/lua.proto#extensions-filters-http-lua-v3-luaperroute
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/lua/v3/lua.proto#extensions-filters-http-lua-v3-luaperroute
               "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
 
               ## if true, disables the Lua filter on this HTTP_ROUTE
@@ -99,15 +115,23 @@ spec:
           typed_per_filter_config:
             ## the ExtAuthz filter is called "envoy.filters.http.ext_authz"
             envoy.filters.http.ext_authz:
-              ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-extauthzperroute
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-extauthzperroute
               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
 
               ## if true, disables the ExtAuthz filter on this HTTP_ROUTE
               disabled: true
 
+            ## the JwtAuthn filter is called "envoy.filters.http.jwt_authn"
+            envoy.filters.http.jwt_authn:
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/jwt_authn/v3/config.proto#extensions-filters-http-jwt-authn-v3-perrouteconfig
+              "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+
+              ## if true, disables the JwtAuthn filter on this HTTP_ROUTE
+              disabled: true
+
             ## the Lua filter that sets USERID_HEADER is called "envoy.filters.http.lua.set_userid_header"
             envoy.filters.http.lua.set_userid_header:
-              ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/http/lua/v3/lua.proto#extensions-filters-http-lua-v3-luaperroute
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/lua/v3/lua.proto#extensions-filters-http-lua-v3-luaperroute
               "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
 
               ## if true, disables the Lua filter on this HTTP_ROUTE
@@ -131,15 +155,23 @@ spec:
           typed_per_filter_config:
             ## the ExtAuthz filter is called "envoy.filters.http.ext_authz"
             envoy.filters.http.ext_authz:
-              ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-extauthzperroute
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-extauthzperroute
               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
 
               ## if true, disables the ExtAuthz filter on this HTTP_ROUTE
               disabled: true
 
+            ## the JwtAuthn filter is called "envoy.filters.http.jwt_authn"
+            envoy.filters.http.jwt_authn:
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/jwt_authn/v3/config.proto#extensions-filters-http-jwt-authn-v3-perrouteconfig
+              "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+
+              ## if true, disables the JwtAuthn filter on this HTTP_ROUTE
+              disabled: true
+
             ## the Lua filter that sets USERID_HEADER is called "envoy.filters.http.lua.set_userid_header"
             envoy.filters.http.lua.set_userid_header:
-              ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/http/lua/v3/lua.proto#extensions-filters-http-lua-v3-luaperroute
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/lua/v3/lua.proto#extensions-filters-http-lua-v3-luaperroute
               "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
 
               ## if true, disables the Lua filter on this HTTP_ROUTE
@@ -164,15 +196,23 @@ spec:
           typed_per_filter_config:
             ## the ExtAuthz filter is called "envoy.filters.http.ext_authz"
             envoy.filters.http.ext_authz:
-              ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-extauthzperroute
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-extauthzperroute
               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
 
               ## if true, disables the ExtAuthz filter on this HTTP_ROUTE
               disabled: true
 
+            ## the JwtAuthn filter is called "envoy.filters.http.jwt_authn"
+            envoy.filters.http.jwt_authn:
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/jwt_authn/v3/config.proto#extensions-filters-http-jwt-authn-v3-perrouteconfig
+              "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+
+              ## if true, disables the JwtAuthn filter on this HTTP_ROUTE
+              disabled: true
+
             ## the Lua filter that sets USERID_HEADER is called "envoy.filters.http.lua.set_userid_header"
             envoy.filters.http.lua.set_userid_header:
-              ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/http/lua/v3/lua.proto#extensions-filters-http-lua-v3-luaperroute
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/lua/v3/lua.proto#extensions-filters-http-lua-v3-luaperroute
               "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
 
               ## if true, disables the Lua filter on this HTTP_ROUTE
@@ -195,15 +235,23 @@ spec:
           typed_per_filter_config:
             ## the ExtAuthz filter is called "envoy.filters.http.ext_authz"
             envoy.filters.http.ext_authz:
-              ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-extauthzperroute
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-extauthzperroute
               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
 
               ## if true, disables the ExtAuthz filter on this HTTP_ROUTE
               disabled: true
 
+            ## the JwtAuthn filter is called "envoy.filters.http.jwt_authn"
+            envoy.filters.http.jwt_authn:
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/jwt_authn/v3/config.proto#extensions-filters-http-jwt-authn-v3-perrouteconfig
+              "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+
+              ## if true, disables the JwtAuthn filter on this HTTP_ROUTE
+              disabled: true
+
             ## the Lua filter that sets USERID_HEADER is called "envoy.filters.http.lua.set_userid_header"
             envoy.filters.http.lua.set_userid_header:
-              ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/http/lua/v3/lua.proto#extensions-filters-http-lua-v3-luaperroute
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/lua/v3/lua.proto#extensions-filters-http-lua-v3-luaperroute
               "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
 
               ## if true, disables the Lua filter on this HTTP_ROUTE

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/EnvoyFilter-ext-authz.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/EnvoyFilter-ext-authz.yaml
@@ -32,21 +32,21 @@ spec:
         value:
           name: envoy.filters.http.ext_authz
           typed_config:
-            ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-extauthz
+            ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-extauthz
             "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
 
             ## if `false`, ext-authz will reject client requests and return a Forbidden response if the communication
             ## with the authorization service has failed, or if the authorization service has returned a HTTP 5xx error.
             failure_mode_allow: false
 
-            ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-httpservice
+            ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-httpservice
             http_service:
               server_uri:
                 uri: "http://oauth2-proxy.{{ .Values.deployKF.auth.namespace }}.svc.{{ .Values.deployKF.clusterDomain }}:4180"
                 cluster: "outbound|4180||oauth2-proxy.{{ .Values.deployKF.auth.namespace }}.svc.{{ .Values.deployKF.clusterDomain }}"
-                timeout: 5.00s
+                timeout: 5s
 
-              ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-authorizationrequest
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-authorizationrequest
               authorization_request:
                 ## headers from the client request that are sent to oauth2-proxy (during authentication)
                 ## NOTE: envoy automatically adds: `Host`, `Method`, `Path`, `Content-Length`, `Authorization`
@@ -61,7 +61,7 @@ spec:
                     - exact: x-forwarded-proto
                       ignore_case: true
 
-              ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-authorizationresponse
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-authorizationresponse
               authorization_response:
                 ## headers from oauth2-proxy that overwrite those in the client request (on authentication success)
                 ## NOTE: the client never sees these headers, only the downstream apps
@@ -88,7 +88,7 @@ spec:
                       ignore_case: true
 
     ################################################################################
-    ## FILTER 2 - Set USERID_HEADER from `x-auth-request-email`
+    ## FILTER 2 - Verify JWT, and path access by JWT audience
     ################################################################################
     - applyTo: HTTP_FILTER
       match:
@@ -103,12 +103,82 @@ spec:
         ## insert our filter just AFTER our `envoy.filters.http.ext_authz` filter
         operation: INSERT_AFTER
         value:
+          name: envoy.filters.http.jwt_authn
+          typed_config:
+            ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/jwt_authn/v3/config.proto#extensions-filters-http-jwt-authn-v3-jwtauthentication
+            "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
+
+            ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/jwt_authn/v3/config.proto#envoy-v3-api-msg-extensions-filters-http-jwt-authn-v3-jwtprovider
+            providers:
+              deploykf_dex:
+                ## must match the issuer presented by the dex server
+                {{- if .Values.deployKF.gateway.tls.enabled }}
+                issuer: "https://{{ .Values.deployKF_helpers.deploykf_gateway.https_endpoint }}/dex"
+                {{- else }}
+                issuer: "http://{{ .Values.deployKF_helpers.deploykf_gateway.http_endpoint }}/dex"
+                {{- end }}
+
+                ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/jwt_authn/v3/config.proto#envoy-v3-api-msg-extensions-filters-http-jwt-authn-v3-remotejwks
+                remote_jwks:
+                  http_uri:
+                    uri: "http://dex.{{ .Values.deployKF.auth.namespace }}.svc.{{ .Values.deployKF.clusterDomain }}:5556/dex/keys"
+                    cluster: "outbound|5556||dex.{{ .Values.deployKF.auth.namespace }}.svc.{{ .Values.deployKF.clusterDomain }}"
+                    timeout: 5s
+                  cache_duration: 300s
+
+                ## if true, the Authorization token header is not stripped after verification
+                forward: true
+
+                ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/jwt_authn/v3/config.proto#envoy-v3-api-msg-extensions-filters-http-jwt-authn-v3-jwtheader
+                from_headers:
+                  - name: authorization
+                    value_prefix: "Bearer "
+
+            ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/jwt_authn/v3/config.proto#envoy-v3-api-msg-extensions-filters-http-jwt-authn-v3-requirementrule
+            rules:
+              {{- if and .Values.deployKF.kubeflow.pipelines.enabled .Values.deployKF.auth.dex.clients.kubeflowPipelinesSDK.enabled }}
+              ## kubeflow pipelines api
+              - match:
+                  prefix: "/pipeline"
+                requires:
+                  provider_and_audiences:
+                    provider_name: deploykf_dex
+                    audiences:
+                      - {{ .Values.deployKF.auth.dex.clients.oauth2Proxy.clientId | quote }}
+                      - {{ .Values.deployKF.auth.dex.clients.kubeflowPipelinesSDK.clientId | quote }}
+              {{- end }}
+
+              ## all remaining paths
+              - match:
+                  prefix: "/"
+                requires:
+                  provider_and_audiences:
+                    provider_name: deploykf_dex
+                    audiences:
+                      - {{ .Values.deployKF.auth.dex.clients.oauth2Proxy.clientId | quote }}
+
+    ################################################################################
+    ## FILTER 3 - Set USERID_HEADER from `x-auth-request-email`
+    ################################################################################
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: envoy.filters.network.http_connection_manager
+              subFilter:
+                name: envoy.filters.http.jwt_authn
+      patch:
+        ## insert our filter just AFTER our `envoy.filters.http.jwt_authn` filter
+        operation: INSERT_AFTER
+        value:
           name: envoy.filters.http.lua.set_userid_header
           typed_config:
-            ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/http/lua/v3/lua.proto
+            ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/lua/v3/lua.proto
             "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
 
-            ## https://www.envoyproxy.io/docs/envoy/v1.18.4/configuration/http/http_filters/lua_filter#config-http-filters-lua
+            ## https://www.envoyproxy.io/docs/envoy/v1.23.1/configuration/http/http_filters/lua_filter#config-http-filters-lua
             inline_code: |
               function envoy_on_request(request_handle)
 

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/EnvoyFilter-kubeflow-pipelines.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/EnvoyFilter-kubeflow-pipelines.yaml
@@ -40,10 +40,10 @@ spec:
         value:
           name: envoy.filters.http.lua.kfp_redirect_artifact_namespaces
           typed_config:
-            ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/http/lua/v3/lua.proto
+            ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/lua/v3/lua.proto
             "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
 
-            ## https://www.envoyproxy.io/docs/envoy/v1.18.4/configuration/http/http_filters/lua_filter#config-http-filters-lua
+            ## https://www.envoyproxy.io/docs/envoy/v1.23.1/configuration/http/http_filters/lua_filter#config-http-filters-lua
             inlineCode: |
               function envoy_on_request(request_handle)
                 -- empty lua function
@@ -65,10 +65,10 @@ spec:
         value:
           typed_per_filter_config:
             envoy.filters.http.lua.kfp_redirect_artifact_namespaces:
-              ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/http/lua/v3/lua.proto#extensions-filters-http-lua-v3-luaperroute
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/lua/v3/lua.proto#extensions-filters-http-lua-v3-luaperroute
               "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
 
-              ## https://www.envoyproxy.io/docs/envoy/v1.18.4/configuration/http/http_filters/lua_filter#config-http-filters-lua
+              ## https://www.envoyproxy.io/docs/envoy/v1.23.1/configuration/http/http_filters/lua_filter#config-http-filters-lua
               source_code:
                 inline_string: |
                   function extract_url_namespaces(url_path)

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/EnvoyFilter-xff-num-trusted-hops.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/EnvoyFilter-xff-num-trusted-hops.yaml
@@ -28,7 +28,7 @@ spec:
         operation: MERGE
         value:
           typed_config:
-            ## https://www.envoyproxy.io/docs/envoy/v1.18.4/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#extensions-filters-network-http-connection-manager-v3-httpconnectionmanager
+            ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#extensions-filters-network-http-connection-manager-v3-httpconnectionmanager
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
 
             ## the number of additional ingress proxy hops from the right side of the `x-forwarded-for` HTTP header

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/values.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/values.yaml
@@ -1,4 +1,13 @@
 ########################################
+## SHARED | deploykf-helpers
+########################################
+deployKF_helpers:
+  deploykf_gateway:
+    http_endpoint: {{< (tmpl.Exec "deploykf_gateway.http_endpoint" .) | quote >}}
+    https_endpoint: {{< (tmpl.Exec "deploykf_gateway.https_endpoint" .) | quote >}}
+
+
+########################################
 ## SHARED | deploykf
 ########################################
 deployKF:
@@ -31,6 +40,13 @@ deployKF:
 
   auth:
     namespace: {{< .Values.deploykf_core.deploykf_auth.namespace | quote >}}
+    dex:
+      clients:
+        oauth2Proxy:
+          clientId: {{< .Values.deploykf_core.deploykf_auth.dex.clients.oauth2Proxy.clientId | quote >}}
+        kubeflowPipelinesSDK:
+          enabled: {{< .Values.deploykf_core.deploykf_auth.dex.clients.kubeflowPipelinesSDK.enabled | conv.ToBool >}}
+          clientId: {{< .Values.deploykf_core.deploykf_auth.dex.clients.kubeflowPipelinesSDK.clientId | quote >}}
 
   gateway:
     name: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.name | quote >}}


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR adds support for browser-based authentication (also known as "out-of-band" OIDC login) with the _Kubeflow Pipelines SDK_.

This is achieved by making the following changes:

- Adding a public OIDC client to Dex named `kubeflow-pipelines-sdk`
- Using the Dex `urn:ietf:wg:oauth:2.0:oob` redirect URI (prompts the user to copy a code)
- Configuring oauth2-proxy to trust requests with a bearer JWT (not only with its own cookie)

We have also added another layer of security where we can restrict HTTP paths depending on the JWT bearer `aud`.
For example, JWT tokens generated under the new `kubeflow-pipelines-sdk` OIDC client, can ONLY access the `/pipelines` API path, but NOT the deployKF dashboard or any other paths.