### PR TITLE
fix: don't mount trust bundles with own cert-manager

### DIFF
--- a/generator/helpers/deploykf-gateway.tpl
+++ b/generator/helpers/deploykf-gateway.tpl
@@ -25,7 +25,7 @@
 ## - NOTE: empty means false, non-empty means true
 ##
 {{<- define "deploykf_gateway.is_self_signed_cert" ->}}
-{{<- if and (.Values.deploykf_core.deploykf_istio_gateway.gateway.tls.enabled) (.Values.deploykf_dependencies.cert_manager.clusterIssuer.enabled) (eq .Values.deploykf_dependencies.cert_manager.clusterIssuer.type "SELF_SIGNED") ->}}
+{{<- if and (.Values.deploykf_dependencies.cert_manager.enabled) (.Values.deploykf_core.deploykf_istio_gateway.gateway.tls.enabled) (.Values.deploykf_dependencies.cert_manager.clusterIssuer.enabled) (eq .Values.deploykf_dependencies.cert_manager.clusterIssuer.type "SELF_SIGNED") ->}}
 true
 {{<- end ->}}
 {{<- end ->}}


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR fixes a bug where we followed the self-signed gateway code path when the user brought their own `cert-manager` deployment, unless they explicitly did something like disabling `deploykf_dependencies.cert_manager.clusterIssuer.enabled`.

As there is no reasonable case where someone would want to bring their own `cert-manager` but use a self-signed certificate, we now assume that the gateway is NOT using a self-signed certificate, when the user brings their own `cert-manager`.

This primarily fixes an issue where Pods would fail to start because we would try and mount the `trust-manager` Bundle ConfigMaps as volumes on Pods, but the Bundle would not exist when the user disables the embedded `cert-manager`.