### PR TITLE
feat: kyverno policy for image-pull-secrets

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -326,6 +326,33 @@ deploykf_dependencies:
       - apiGroups: [ "kubeflow.org" ]
         resources: [ "poddefaults" ]
 
+    ## kyverno policy configs
+    ##
+    clusterPolicies:
+
+      ## a policy to automatically replicate and inject pod imagePullSecrets
+      ##  - this policy is useful for ~private~ container registries or avoiding ~pull limits~
+      ##
+      imagePullSecrets:
+        enabled: false
+
+        ## a list of namespaces to exclude from this policy
+        ##  - note, all namespaces are included except those excluded here (and the `kyverno.namespace`)
+        ##  - wildcards are supported "*" (zero or many characters) and “?” (at least one character)
+        ##
+        excludeNamespaces:
+          - "argocd"
+          - "kube-system"
+
+        ## a list of registry credentials
+        ##  - each element is a map with the following keys:
+        ##     - `existingSecret`: the name of an existing 'kubernetes.io/dockerconfigjson' type secret
+        ##     - `existingSecretNamespace`: the namespace containing the existing secret (default: `kyverno.namespace`)
+        ##  - for more information on creating a registry secret, see:
+        ##    https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+        ##
+        registryCredentials: []
+
 
 ## --------------------------------------------------------------------------------
 ##

--- a/generator/templates/argocd/applications/deploykf-dependencies/kyverno.yaml
+++ b/generator/templates/argocd/applications/deploykf-dependencies/kyverno.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: {{< .Values.argocd.namespace | quote >}}
   annotations:
     ## applications in 'deploykf-dependencies' come first
-    ## NOTE: in this group, each application has a separate wave to avoid conflicts due to webhooks
-    argocd.argoproj.io/sync-wave: "12"
+    ## NOTE: kyverno is last to ensure it starts after the CRDs from other applications are applied, for RBAC aggregation
+    argocd.argoproj.io/sync-wave: "19"
   labels:
     app.kubernetes.io/name: kyverno
     app.kubernetes.io/component: deploykf-dependencies

--- a/generator/templates/manifests/deploykf-dependencies/kyverno/templates/ClusterPolicy-image-pull-secrets.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/kyverno/templates/ClusterPolicy-image-pull-secrets.yaml
@@ -1,0 +1,67 @@
+{{- if and .Values.deployKF.kyverno.clusterPolicies.imagePullSecrets.enabled .Values.deployKF.kyverno.clusterPolicies.imagePullSecrets.registryCredentials }}
+{{- $exclude_namespaces := .Release.Namespace | append .Values.deployKF.kyverno.clusterPolicies.imagePullSecrets.excludeNamespaces | uniq }}
+{{- $target_secret_names := list }}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: clone-image-pull-secrets
+  annotations:
+    ## we must sync kyverno resources after kyverno itself
+    argocd.argoproj.io/sync-wave: "10"
+    ## kyverno policies with "generate" cant be updated: https://github.com/kyverno/kyverno/issues/7718
+    argocd.argoproj.io/sync-options: Replace=true
+    ## we don't want auto-generation of rules for deployments/etc. https://kyverno.io/docs/writing-policies/autogen/
+    pod-policies.kyverno.io/autogen-controllers: "none"
+spec:
+  generateExisting: true
+  rules:
+    {{- range $index, $credentials := .Values.deployKF.kyverno.clusterPolicies.imagePullSecrets.registryCredentials }}
+    {{- $source_secret__name := $credentials.existingSecret }}
+    {{- $source_secret__namespace := $credentials.existingSecretNamespace | default $.Release.Namespace }}
+    {{- $target_secret__name := printf "cloned--image-pull-secret-%d" $index }}
+    {{- $target_secret_names = $target_secret__name | append $target_secret_names }}
+    ## clone secret {{ $index }} from its source namespace into ALL namespaces
+    - name: {{ printf "clone-image-pull-secret-%d" $index | quote }}
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+      exclude:
+        any:
+          - resources:
+              names: {{ $exclude_namespaces | toJson }}
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: {{ $target_secret__name | quote }}
+        namespace: {{ `"{{ request.object.metadata.name }}"` }}
+        synchronize: true
+        clone:
+          namespace: {{ $source_secret__namespace | quote }}
+          name: {{ $source_secret__name | quote }}
+    {{- end }}
+
+    ## add all the ~cloned~ secrets to the list of imagePullSecrets for all pods
+    - name: add-image-pull-secrets-to-pods
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              operations:
+                - CREATE
+      exclude:
+        any:
+          - resources:
+              namespaces: {{ $exclude_namespaces | toJson }}
+      mutate:
+        ## NOTE: we use an append patch here because we don't want to overwrite any existing imagePullSecrets
+        patchesJson6902: |-
+          {{- range $secret_name := $target_secret_names }}
+          - op: add
+            path: "/spec/imagePullSecrets/-"
+            value:
+              name: {{ $secret_name | quote }}
+          {{- end }}
+{{- end }}

--- a/generator/templates/manifests/deploykf-dependencies/kyverno/values.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/kyverno/values.yaml
@@ -28,6 +28,13 @@ deployKF:
     - {{< (tpl $manifest $) | quote >}}
     {{<- end >}}
 
+  kyverno:
+    clusterPolicies:
+      imagePullSecrets:
+        enabled: {{< .Values.deploykf_dependencies.kyverno.clusterPolicies.imagePullSecrets.enabled | conv.ToBool >}}
+        excludeNamespaces: {{< .Values.deploykf_dependencies.kyverno.clusterPolicies.imagePullSecrets.excludeNamespaces | toJSON >}}
+        registryCredentials: {{< .Values.deploykf_dependencies.kyverno.clusterPolicies.imagePullSecrets.registryCredentials | toJSON >}}
+
 
 ########################################
 ## DEPENDENCY | kyverno


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR adds a Kyverno ClusterPolicy which automatically replicates and injects Pod imagePullSecrets across the cluster.
This policy is primarily needed when using __private container registries__ or for avoiding DockerHub __pull limits__.

As the new ClusterPolicy lives in the embedded Kyverno chart, we had to make some small changes to the `sync_argocd_apps.sh` script. Previously, we were always force-syncing ClusterPolicies (with `clone` or `generate` in the name), even if they were "missing" from the cluster, which caused a failure on the first sync, as this would result in the ClusterPolicy being applied before its CRD.