### PR TITLE
refactor: always use `v1` kyverno resources

### DIFF
--- a/generator/templates/manifests/deploykf-core/deploykf-auth/templates/ClusterPolicy--restart-on-secret-updates.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-auth/templates/ClusterPolicy--restart-on-secret-updates.yaml
@@ -42,7 +42,7 @@
 {{- $secret_list__env_vars := (include "deploykf-auth.secret_list__env_vars" .) | fromYamlArray | uniq }}
 
 {{- if $secret_list__env_vars }}
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: deploykf-auth--restart-on-secret-updates

--- a/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/ClusterPolicy--restart-on-secret-updates.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/ClusterPolicy--restart-on-secret-updates.yaml
@@ -14,7 +14,7 @@
 {{- $secret_list__env_vars := (include "deploykf-minio.secret_list__env_vars" .) | fromYamlArray | uniq }}
 
 {{- if $secret_list__env_vars }}
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: deploykf-minio--restart-on-secret-updates

--- a/generator/templates/manifests/deploykf-opt/deploykf-mysql/templates/ClusterPolicy--restart-on-secret-updates.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-mysql/templates/ClusterPolicy--restart-on-secret-updates.yaml
@@ -25,7 +25,7 @@
 {{- $secret_list__env_vars := (include "deploykf-mysql.secret_list__env_vars" .) | fromYamlArray | uniq }}
 
 {{- if $secret_list__env_vars }}
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: deploykf-mysql--restart-on-secret-updates

--- a/generator/templates/manifests/kubeflow-tools/katib/resources/restart-on-mysql-secret-update-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/katib/resources/restart-on-mysql-secret-update-clusterpolicy.yaml
@@ -1,5 +1,5 @@
 {{<- if not (tmpl.Exec "kubeflow_katib.mysql.auth.secret_is_cloned" .) >}}
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: kubeflow-katib--restart-on-secret-update--mysql

--- a/generator/templates/manifests/kubeflow-tools/pipelines/resources/restart-on-mysql-secret-update-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/resources/restart-on-mysql-secret-update-clusterpolicy.yaml
@@ -1,5 +1,5 @@
 {{<- if not (tmpl.Exec "kubeflow_pipelines.mysql.auth.secret_is_cloned" .) >}}
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: kubeflow-pipelines--restart-on-secret-update--mysql

--- a/generator/templates/manifests/kubeflow-tools/pipelines/resources/restart-on-pipeline-configmap-update-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/resources/restart-on-pipeline-configmap-update-clusterpolicy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: kubeflow-pipelines--restart-on-pipeline-configmap-update


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR is a minor refactor to ensure we only use `apiVersion` = `kyverno.io/v1` for Kyverno resources.

As far I as I can tell they are equivalent in Kyverno version `1.10.0`.