### PR TITLE
fix: ensure kyverno has permission to manage PodDefaults

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -322,9 +322,7 @@ deploykf_dependencies:
     ##  - a list of extra kubernetes resources to allow kyverno to generate and manage
     ##  - each element is a map with keys `apiGroups` and `resources` that contain lists of strings
     ##
-    extraResourceRules:
-      - apiGroups: [ "kubeflow.org" ]
-        resources: [ "poddefaults" ]
+    extraResourceRules: []
 
 
 ## --------------------------------------------------------------------------------

--- a/generator/templates/manifests/deploykf-dependencies/kyverno/values.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/kyverno/values.yaml
@@ -12,6 +12,11 @@ rules:
   ## there permissions are so that kyverno can mutate these resources for automatic restarts on secret changes
   - apiGroups: [ "apps" ]
     resources: [ "statefulsets" ]
+  {{<- if .Values.kubeflow_tools.poddefaults_webhook.enabled >}}
+  ## these permissions are needed for the automatic creation of PodDefaults
+  - apiGroups: [ "kubeflow.org" ]
+    resources: [ "poddefaults" ]
+  {{<- end >}}
 {{<- end >}}
 {{<- $extra_resources := ((tmpl.Exec "default_extra_resources" .) | yaml).rules >}}
 {{<- range $rule := .Values.deploykf_dependencies.kyverno.extraResourceRules >}}


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR ensures that even if the user sets their own `deploykf_dependencies.kyverno.extraResourceRules`, that Kyverno will have the required RBAC permissions to manage `PodDefault` resources.