### PR TITLE
fix: prevent kyverno log spam on missing generate context

### DIFF
--- a/generator/templates/manifests/kubeflow-tools/pipelines/resources/generate-profile-resources-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/resources/generate-profile-resources-clusterpolicy.yaml
@@ -213,6 +213,14 @@ spec:
           configMap:
             name: profile-tools--kubeflow-pipelines
             namespace: "{{ request.object.metadata.name }}"
+      preconditions:
+        all:
+          - key: "{{ tool_config.data.objectStoreAuth_existingSecretAccessKeyKey || '' }}"
+            operator: NotEquals
+            value: ""
+          - key: "{{ tool_config.data.objectStoreAuth_existingSecretSecretKeyKey || '' }}"
+            operator: NotEquals
+            value: ""
       generate:
         apiVersion: apps/v1
         kind: Deployment
@@ -355,6 +363,14 @@ spec:
           configMap:
             name: profile-tools--kubeflow-pipelines
             namespace: "{{ request.object.metadata.name }}"
+      preconditions:
+        all:
+          - key: "{{ tool_config.data.objectStoreAuth_existingSecretAccessKeyKey || '' }}"
+            operator: NotEquals
+            value: ""
+          - key: "{{ tool_config.data.objectStoreAuth_existingSecretSecretKeyKey || '' }}"
+            operator: NotEquals
+            value: ""
       generate:
         apiVersion: v1
         kind: ConfigMap

--- a/generator/templates/manifests/kubeflow-tools/pipelines/resources/generate-profile-resources-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/resources/generate-profile-resources-clusterpolicy.yaml
@@ -208,6 +208,8 @@ spec:
               selector:
                 matchLabels:
                   pipelines.kubeflow.org/enabled: "true"
+      {{<- /* currently, the ConfigMap/profile-tools--kubeflow-pipelines is not created when fromEnv is true */ ->}}
+      {{<- if not .Values.kubeflow_tools.pipelines.objectStore.auth.fromEnv >}}
       context:
         - name: tool_config
           configMap:
@@ -221,6 +223,7 @@ spec:
           - key: "{{ tool_config.data.objectStoreAuth_existingSecretSecretKeyKey || '' }}"
             operator: NotEquals
             value: ""
+      {{<- end >}}
       generate:
         apiVersion: apps/v1
         kind: Deployment

--- a/generator/templates/manifests/kubeflow-tools/pipelines/resources/generate-profile-resources-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/resources/generate-profile-resources-clusterpolicy.yaml
@@ -208,7 +208,7 @@ spec:
               selector:
                 matchLabels:
                   pipelines.kubeflow.org/enabled: "true"
-      {{<- /* currently, the ConfigMap/profile-tools--kubeflow-pipelines is not created when fromEnv is true */ ->}}
+      {{<- /* NOTE: the `ConfigMap/profile-tools--kubeflow-pipelines` is NOT created when fromEnv is true */ ->}}
       {{<- if not .Values.kubeflow_tools.pipelines.objectStore.auth.fromEnv >}}
       context:
         - name: tool_config
@@ -361,6 +361,8 @@ spec:
               selector:
                 matchLabels:
                   pipelines.kubeflow.org/enabled: "true"
+      {{<- /* NOTE: the `ConfigMap/profile-tools--kubeflow-pipelines` is NOT created when fromEnv is true */ ->}}
+      {{<- if not .Values.kubeflow_tools.pipelines.objectStore.auth.fromEnv >}}
       context:
         - name: tool_config
           configMap:
@@ -374,6 +376,7 @@ spec:
           - key: "{{ tool_config.data.objectStoreAuth_existingSecretSecretKeyKey || '' }}"
             operator: NotEquals
             value: ""
+      {{<- end >}}
       generate:
         apiVersion: v1
         kind: ConfigMap


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
Before this PR, if the `ConfigMap/profile-tools--kubeflow-pipelines` was not present in a Profile Namespace, for any reason, Kyvenro would spam its logs saying that it was missing.