### PR TITLE
feat: add value for istio revision namespace labels

### DIFF
--- a/generator/templates/argocd/namespaces/deploykf-core/deploykf-auth.yaml
+++ b/generator/templates/argocd/namespaces/deploykf-core/deploykf-auth.yaml
@@ -3,5 +3,9 @@ kind: Namespace
 metadata:
   name: {{< .Values.deploykf_core.deploykf_auth.namespace | quote >}}
   labels:
+    {{- if .Values.deploykf_dependencies.istio.revision }}
+    istio.io/rev: {{ .Values.deploykf_dependencies.istio.revision }}
+    {{- else }}
     istio-injection: enabled
+    {{- end }}
     deploykf.github.io/inject-root-ca-cert: enabled

--- a/generator/templates/argocd/namespaces/deploykf-core/deploykf-dashboard.yaml
+++ b/generator/templates/argocd/namespaces/deploykf-core/deploykf-dashboard.yaml
@@ -3,5 +3,9 @@ kind: Namespace
 metadata:
   name: {{< .Values.deploykf_core.deploykf_dashboard.namespace | quote >}}
   labels:
+    {{- if .Values.deploykf_dependencies.istio.revision }}
+    istio.io/rev: {{ .Values.deploykf_dependencies.istio.revision }}
+    {{- else }}
     istio-injection: enabled
+    {{- end }}
     deploykf.github.io/inject-root-ca-cert: enabled

--- a/generator/templates/argocd/namespaces/deploykf-core/deploykf-istio-gateway.yaml
+++ b/generator/templates/argocd/namespaces/deploykf-core/deploykf-istio-gateway.yaml
@@ -3,5 +3,9 @@ kind: Namespace
 metadata:
   name: {{< .Values.deploykf_core.deploykf_istio_gateway.namespace | quote >}}
   labels:
+    {{- if .Values.deploykf_dependencies.istio.revision }}
+    istio.io/rev: {{ .Values.deploykf_dependencies.istio.revision }}
+    {{- else }}
     istio-injection: enabled
+    {{- end }}
     deploykf.github.io/inject-root-ca-cert: enabled

--- a/generator/templates/argocd/namespaces/deploykf-opt/deploykf-minio.yaml
+++ b/generator/templates/argocd/namespaces/deploykf-opt/deploykf-minio.yaml
@@ -3,5 +3,9 @@ kind: Namespace
 metadata:
   name: {{< .Values.deploykf_opt.deploykf_minio.namespace | quote >}}
   labels:
+    {{- if .Values.deploykf_dependencies.istio.revision }}
+    istio.io/rev: {{ .Values.deploykf_dependencies.istio.revision }}
+    {{- else }}
     istio-injection: enabled
+    {{- end }}
     deploykf.github.io/inject-root-ca-cert: enabled

--- a/generator/templates/argocd/namespaces/kubeflow-dependencies/kubeflow-argo-workflows.yaml
+++ b/generator/templates/argocd/namespaces/kubeflow-dependencies/kubeflow-argo-workflows.yaml
@@ -3,5 +3,9 @@ kind: Namespace
 metadata:
   name: {{< .Values.kubeflow_dependencies.kubeflow_argo_workflows.namespace | quote >}}
   labels:
+    {{- if .Values.deploykf_dependencies.istio.revision }}
+    istio.io/rev: {{ .Values.deploykf_dependencies.istio.revision }}
+    {{- else }}
     istio-injection: enabled
+    {{- end }}
     deploykf.github.io/inject-root-ca-cert: enabled

--- a/generator/templates/argocd/namespaces/kubeflow-tools/kubeflow.yaml
+++ b/generator/templates/argocd/namespaces/kubeflow-tools/kubeflow.yaml
@@ -4,5 +4,9 @@ metadata:
   name: kubeflow
   labels:
     control-plane: kubeflow
+    {{- if .Values.deploykf_dependencies.istio.revision }}
+    istio.io/rev: {{ .Values.deploykf_dependencies.istio.revision }}
+    {{- else }}
     istio-injection: enabled
+    {{- end }}
     deploykf.github.io/inject-root-ca-cert: enabled


### PR DESCRIPTION
Allows using istio with a [revision-based set up](https://istio.io/v1.16/blog/2021/revision-tags/), that is, applying `istio.io/rev` labels to the Namespaces.

closes: #62