### PR TITLE
feat: disable default plugins and resource-quotas in specific profiles

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -766,6 +766,8 @@ deploykf_core:
       ##           https://github.com/kubeflow/kubeflow/blob/v1.7.0/components/profile-controller/controllers/plugin_iam.go#L30
       ##         - spec for WorkloadIdentity:
       ##           https://github.com/kubeflow/kubeflow/blob/v1.7.0/components/profile-controller/controllers/plugin_workload_identity.go#L39
+      ##  - override these defaults for a specific profile by setting `plugins` in that profile,
+      ##    to disable all plugins for that profile, set an empty list `[]`
       ##
       ## ____ EXAMPLE _______________
       ##  plugins:
@@ -785,6 +787,8 @@ deploykf_core:
       ## the default resource quota for profiles, when not explicitly specified
       ##  - spec for ResourceQuotaSpec:
       ##    https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcequotaspec-v1-core
+      ##  - override these defaults for a specific profile by setting `resourceQuotaSpec` in that profile,
+      ##    to disable resource quotas for that profile, set an empty map `{}`
       ##
       resourceQuotaSpec: {}
 

--- a/generator/templates/manifests/deploykf-core/deploykf-profiles-generator/templates/profile.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-profiles-generator/templates/profile.yaml
@@ -25,10 +25,10 @@
 {{- end }}
 
 {{- /* get the profile's plugins */ -}}
-{{- $profile_plugins := $profile.plugins | default $.Values.profileDefaults.plugins }}
+{{- $profile_plugins := $profile | dig "plugins" $.Values.profileDefaults.plugins }}
 
 {{- /* get the profile's resourceQuotaSpec */ -}}
-{{- $profile_resourceQuotaSpec := $profile.resourceQuotaSpec | default $.Values.profileDefaults.resourceQuotaSpec }}
+{{- $profile_resourceQuotaSpec := $profile | dig "resourceQuotaSpec" $.Values.profileDefaults.resourceQuotaSpec }}
 ---
 apiVersion: kubeflow.org/v1
 kind: Profile

--- a/sample-values.yaml
+++ b/sample-values.yaml
@@ -301,8 +301,18 @@ deploykf_core:
       ##           https://github.com/kubeflow/kubeflow/blob/v1.7.0/components/profile-controller/controllers/plugin_iam.go#L30
       ##         - spec for WorkloadIdentity:
       ##           https://github.com/kubeflow/kubeflow/blob/v1.7.0/components/profile-controller/controllers/plugin_workload_identity.go#L39
+      ##  - override these defaults for a specific profile by setting `plugins` in that profile,
+      ##    to disable all plugins for that profile, set an empty list `[]`
       ##
       plugins: []
+
+      ## the default resource quota for profiles, when not explicitly specified
+      ##  - spec for ResourceQuotaSpec:
+      ##    https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcequotaspec-v1-core
+      ##  - override these defaults for a specific profile by setting `resourceQuotaSpec` in that profile,
+      ##    to disable resource quotas for that profile, set an empty map `{}`
+      ##
+      resourceQuotaSpec: {}
 
       ## the default tool configs for profiles
       ##


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
The PR allows you to disable the default `plugins` or `resourceQuotaSpec` for a specific profile by setting them to `[]` and `{}` respectively in that profile definition. Previously, these were interpreted as "false" so would have been assigned the defaults, even if explicitly set as empty.

For example, the following will now behave as expected:

```yaml
deploykf_core:
  deploykf_profiles_generator:
    
    profileDefaults:
      plugins:
        - kind: AwsIamForServiceAccount
          spec:
            awsIamRole: arn:aws:iam::000000000000:role/MY_ROLE_NAME
            AnnotateOnly: true
            
      resourceQuotaSpec:
        hard:
          pods: 100

    profiles:
      - name: profile-with-defaults
        members: ...
        
      - name: profile-with-no-plugins
        plugins: []
        members: ...

      - name: profile-with-no-limits
        resourceQuotaSpec: {}
        members: ...
```