### PR TITLE
feat: add value for extending minio policies

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -1038,6 +1038,28 @@ deploykf_opt:
     ##
     policies: []
 
+    ## a list of extra policy statements to add to the default policy
+    ## generated for each user in `deploykf_core.deploykf_profiles_generator.users`
+    ##  - each element is a map with the following keys:
+    ##     - `user` | `group`: the ID of a user or group (mutually exclusive). The additional statements will be added to the specified
+    ##                         user or to all users of the specified group.
+    ##     - `statements`: a list of policy statements to add. Each statement is a minio policy statement as a YAML map with the following keys:
+    ##                     `Effect`, `Action`, `Resource`.
+    ##
+    ## for example:
+    ## extraPolicyStatements:
+    ##    ## additional policy statements for each member of 'team-1' group
+    ##    - group: team-1
+    ##      statements:
+    ##        ## allow members of 'team-1' to see MY_BUCKET_NAME
+    ##        - Effect: Allow
+    ##          Action:
+    ##            - s3:GetBucketLocation
+    ##            - s3:ListBucket
+    ##          Resource:
+    ##            - arn:aws:s3:::MY_BUCKET_NAME
+    extraPolicyStatements: []
+
 
   ## --------------------------------------
   ##            deploykf-mysql

--- a/generator/helpers/deploykf-minio-policies.tpl
+++ b/generator/helpers/deploykf-minio-policies.tpl
@@ -1,0 +1,32 @@
+##
+## Takes a MinIO policy and a list of additional statements as input and appends the statements to the policy.
+## - USAGE: `$policy_yaml := tmpl.Exec "deploykf_minio_policies.append_to_user" (dict "prev_policy" $prev_policy dict "statements" $statements)`
+##
+{{<- define "deploykf_minio_policies.append_to_user" ->}}
+{{<- $statements := .statements >}}
+{{<- $prev_policy := .prev_policy >}}
+Version: "2012-10-17"
+Statement:
+{{<- range $statement := $statements >}}
+- Effect: {{< $statement.Effect >}}
+  Action:
+  {{<- range $action := $statement.Action >}}
+  - {{< $action >}}
+  {{<- end >}}
+  Resource:
+  {{<- range $resource := $statement.Resource >}}
+  - {{< $resource >}}
+  {{<- end >}}
+{{<- end >}}
+{{<- range $prev_statement := $prev_policy.Statement >}}
+- Effect: {{< $prev_statement.Effect >}}
+  Action:
+  {{<- range $action := $prev_statement.Action >}}
+  - {{< $action >}}
+  {{<- end >}}
+  Resource:
+  {{<- range $resource := $prev_statement.Resource >}}
+  - {{< $resource >}}
+  {{<- end >}}
+{{<- end >}}
+{{<- end ->}}

--- a/generator/templates/manifests/deploykf-opt/deploykf-minio/values.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-minio/values.yaml
@@ -211,6 +211,7 @@ minio:
   ##  - these policies are created and/or updated by a post-install job
   ##
   {{<- $policies := .Values.deploykf_opt.deploykf_minio.policies | default coll.Slice >}}
+  {{<- $extraStatements := .Values.deploykf_opt.deploykf_minio.extraPolicyStatements | default coll.Slice >}}
   {{<- if and .Values.kubeflow_tools.pipelines.enabled (not .Values.kubeflow_tools.pipelines.objectStore.useExternal) >}}
   {{<- if eq .Values.deploykf_opt.deploykf_minio.identity.openid.policyClaim "email" >}}
     {{<- $users_id_mapping := tmpl.Exec "runtime/deploykf_profiles__users_id_mapping_json" | json >}}
@@ -231,10 +232,30 @@ minio:
            {{<- $view_profiles = $view_profiles | append $profile_name >}}
          {{<- end >}}
        {{<- end >}}
-       {{<- $policy := tmpl.Exec "kubeflow_pipelines.object_store.user.minio_policy" (dict "edit_profiles" $edit_profiles "view_profiles" $view_profiles "bucket_name" $bucket_name) | yaml >}}
+       {{<- $user_policy := tmpl.Exec "kubeflow_pipelines.object_store.user.minio_policy" (dict "edit_profiles" $edit_profiles "view_profiles" $view_profiles "bucket_name" $bucket_name) | yaml >}}
 
+       {{<- /* add the extra statements for this user, if present */ ->}}
+       {{<- $groups_id_mapping_json := tmpl.Exec "runtime/deploykf_profiles__groups_id_mapping_json" | json >}}
+       {{<- range $statement := $extraStatements >}}
+         {{<- if (index $statement "user") >}}
+           {{<- if eq ($statement.user | conv.ToString) ($user_id | conv.ToString) >}}
+             {{<- $user_policy = tmpl.Exec "deploykf_minio_policies.append_to_user" (dict "prev_policy" $user_policy "statements" $statement.statements) | yaml >}}
+           {{<- end >}}
+         {{<- end >}}
+         {{<- if (index $statement "group") >}}
+           {{<- range $group_name, $users := $groups_id_mapping_json >}}
+             {{<- if eq $statement.group $group_name >}}
+               {{<- range $user := $users >}}
+                 {{<- if eq $user.id $user_id >}}
+                   {{<- $user_policy = tmpl.Exec "deploykf_minio_policies.append_to_user" (dict "prev_policy" $user_policy "statements" $statement.statements) | yaml >}}
+                 {{<- end >}}
+               {{<- end >}}
+             {{<- end >}}
+           {{<- end >}}
+         {{<- end >}}
+       {{<- end >}}
        {{<- /* add the minio policy to the list of policies */ ->}}
-       {{<- $policies = $policies | append (dict "name" $policy_name "policy" $policy) >}}
+       {{<- $policies = $policies | append (dict "name" $policy_name "policy" $user_policy) >}}
     {{<- end >}}
   {{<- end >}}
   {{<- end >}}


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

This PR adds the value `deploykf_opt.deploykf_minio.extraPolicyStatements`, which makes it possible to add custom MinIO policy statements to specific users or groups. In case of groups, there are added to all users of that group.

For example:
```
extraPolicyStatements:

      ## additional policy statements for 'user-1' 
      - user: user-1
        statements:
          ## allow 'user-1' to see MY_BUCKET_NAME
          - Effect: Allow
            Action:
              - s3:GetBucketLocation
              - s3:ListBucket
            Resource:
              - arn:aws:s3:::MY_BUCKET_NAME

      ## additional policy statements for each member of 'team-1' group
      - group: team-1
        statements:
          ## allow members of 'team-1' to see MY_BUCKET_NAME
          - Effect: Allow
            Action:
              - s3:GetBucketLocation
              - s3:ListBucket
            Resource:
              - arn:aws:s3:::MY_BUCKET_NAME
          
          ## allow members of 'team-1' to read/write under MY_BUCKET_NAME/some-prefix/*
          - Effect: Allow
            Action:
              - s3:GetObject
              - s3:PutObject
              - s3:DeleteObject
            Resource:
              - arn:aws:s3:::MY_BUCKET_NAME/some-prefix/*
```

For context, this feature stems from [this discussion](https://github.com/orgs/deployKF/discussions/64).

### Implementation comments

- Instead of modifying [kubeflow_pipelines.object_store.user.minio_policy](https://github.com/deployKF/deployKF/blob/v0.1.3/generator/helpers/kubeflow-pipelines--object-store.tpl#L246-L280) to allow for extra statements, I opted for creating a new one (`generator/helpers/deploykf-minio-policies.tpl`), as this functionality is not really relevant to the kubeflow_pipelines's object_store. Hence, it seems cleaner this way (unless I'm missing something, I'm interested to know your thoughts!). This helper file is used to append policy statements to an existing policy.
   - This helper file also hardcodes the `Version` field to `"2012-10-17"`, as `kubeflow_pipelines.object_store.user.minio_policy` does. It would be cleaner to take the Version from the existing policy (with `Version: {{< $prev_policy.Version >}}`), but the value gets converted to  `2012-10-17Z00:00:00` and I haven't found a way around that. Since it is also hardcoded in other places and is not settable by the user, I don't think it is a big deal, but I am open to feedback.
- Open to any suggestions/improvements on code style or design, as this would be my first contribution here!