### PR TITLE
fix: using AWS IRSA with Kubeflow Pipelines

### DIFF
--- a/generator/templates/manifests/kubeflow-tools/pipelines/files/viewer-pod-template.json
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/files/viewer-pod-template.json
@@ -8,17 +8,23 @@ spec:
           value: {{< .Values.kubeflow_tools.pipelines.bucket.region | quote >}}
         - name: AWS_S3_ENDPOINT
           value: {{< (tmpl.Exec "kubeflow_pipelines.object_store.endpoint" .) | quote >}}
-        {{<- if not .Values.kubeflow_tools.pipelines.objectStore.auth.fromEnv >}}
         - name: AWS_ACCESS_KEY_ID
+          {{<- if .Values.kubeflow_tools.pipelines.objectStore.auth.fromEnv >}}
+          value: ""
+          {{<- else >}}
           valueFrom:
             secretKeyRef:
               name: {{< (tmpl.Exec "kubeflow_pipelines.object_store.auth.secret_name" .) | quote >}}
               key: {{< (tmpl.Exec "kubeflow_pipelines.object_store.auth.access_key_key" .) | quote >}}
+          {{<- end >}}
         - name: AWS_SECRET_ACCESS_KEY
+          {{<- if .Values.kubeflow_tools.pipelines.objectStore.auth.fromEnv >}}
+          value: ""
+          {{<- else >}}
           valueFrom:
             secretKeyRef:
               name: {{< (tmpl.Exec "kubeflow_pipelines.object_store.auth.secret_name" .) | quote >}}
               key: {{< (tmpl.Exec "kubeflow_pipelines.object_store.auth.secret_key_key" .) | quote >}}
-        {{<- end >}}
+          {{<- end >}}
 {{<- end ->}}
 {{< tmpl.Exec "kubeflow-pipelines.viewer-pod-template.yaml" . | yaml | toJSONPretty "  " >}}

--- a/generator/templates/manifests/kubeflow-tools/pipelines/patches/patch-ml-pipeline-deployment.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/patches/patch-ml-pipeline-deployment.yaml
@@ -94,7 +94,9 @@ spec:
                   key: bucketPort
             - name: OBJECTSTORECONFIG_ACCESSKEY
               {{<- if .Values.kubeflow_tools.pipelines.objectStore.auth.fromEnv >}}
-              $patch: delete
+              value: ""
+              valueFrom:
+                $patch: delete
               {{<- else >}}
               valueFrom:
                 secretKeyRef:
@@ -103,7 +105,9 @@ spec:
               {{<- end >}}
             - name: OBJECTSTORECONFIG_SECRETACCESSKEY
               {{<- if .Values.kubeflow_tools.pipelines.objectStore.auth.fromEnv >}}
-              $patch: delete
+              value: ""
+              valueFrom:
+                $patch: delete
               {{<- else >}}
               valueFrom:
                 secretKeyRef:

--- a/generator/templates/manifests/kubeflow-tools/pipelines/patches/patch-ml-pipeline-ui-deployment.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/patches/patch-ml-pipeline-ui-deployment.yaml
@@ -77,7 +77,9 @@ spec:
                   key: bucketSecure
             - name: MINIO_ACCESS_KEY
               {{<- if .Values.kubeflow_tools.pipelines.objectStore.auth.fromEnv >}}
-              $patch: delete
+              value: ""
+              valueFrom:
+                $patch: delete
               {{<- else >}}
               valueFrom:
                 secretKeyRef:
@@ -86,7 +88,9 @@ spec:
               {{<- end >}}
             - name: MINIO_SECRET_KEY
               {{<- if .Values.kubeflow_tools.pipelines.objectStore.auth.fromEnv >}}
-              $patch: delete
+              value: ""
+              valueFrom:
+                $patch: delete
               {{<- else >}}
               valueFrom:
                 secretKeyRef:
@@ -110,7 +114,9 @@ spec:
                   key: bucketEndpoint
             - name: AWS_ACCESS_KEY_ID
               {{<- if .Values.kubeflow_tools.pipelines.objectStore.auth.fromEnv >}}
-              $patch: delete
+              value: ""
+              valueFrom:
+                $patch: delete
               {{<- else >}}
               valueFrom:
                 secretKeyRef:
@@ -119,7 +125,9 @@ spec:
               {{<- end >}}
             - name: AWS_SECRET_ACCESS_KEY
               {{<- if .Values.kubeflow_tools.pipelines.objectStore.auth.fromEnv >}}
-              $patch: delete
+              value: ""
+              valueFrom:
+                $patch: delete
               {{<- else >}}
               valueFrom:
                 secretKeyRef:

--- a/generator/templates/manifests/kubeflow-tools/pipelines/resources/generate-profile-resources-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/resources/generate-profile-resources-clusterpolicy.yaml
@@ -269,18 +269,24 @@ spec:
                         value: {{< tmpl.Exec "kubeflow_pipelines.object_store.port" . | quote >}}
                       - name: MINIO_SSL
                         value: {{< tmpl.Exec "kubeflow_pipelines.object_store.use_ssl" . | quote >}}
-                      {{<- if not .Values.kubeflow_tools.pipelines.objectStore.auth.fromEnv >}}
                       - name: MINIO_ACCESS_KEY
+                        {{<- if .Values.kubeflow_tools.pipelines.objectStore.auth.fromEnv >}}
+                        value: ""
+                        {{<- else >}}
                         valueFrom:
                           secretKeyRef:
                             name: {{< tmpl.Exec "kubeflow_pipelines.object_store.profile.cloned_secret_name" . | quote >}}
                             key: "{{ tool_config.data.objectStoreAuth_existingSecretAccessKeyKey }}"
+                        {{<- end >}}
                       - name: MINIO_SECRET_KEY
+                        {{<- if .Values.kubeflow_tools.pipelines.objectStore.auth.fromEnv >}}
+                        value: ""
+                        {{<- else >}}
                         valueFrom:
                           secretKeyRef:
                             name: {{< tmpl.Exec "kubeflow_pipelines.object_store.profile.cloned_secret_name" . | quote >}}
                             key: "{{ tool_config.data.objectStoreAuth_existingSecretSecretKeyKey }}"
-                      {{<- end >}}
+                        {{<- end >}}
 
                       ## ================================
                       ## S3 - Object Store Configs
@@ -289,18 +295,24 @@ spec:
                         value: {{< .Values.kubeflow_tools.pipelines.bucket.region | quote >}}
                       - name: AWS_S3_ENDPOINT
                         value: {{< tmpl.Exec "kubeflow_pipelines.object_store.endpoint" . | quote >}}
-                      {{<- if not .Values.kubeflow_tools.pipelines.objectStore.auth.fromEnv >}}
                       - name: AWS_ACCESS_KEY_ID
+                        {{<- if .Values.kubeflow_tools.pipelines.objectStore.auth.fromEnv >}}
+                        value: ""
+                        {{<- else >}}
                         valueFrom:
                           secretKeyRef:
                             name: {{< tmpl.Exec "kubeflow_pipelines.object_store.profile.cloned_secret_name" . | quote >}}
                             key: "{{ tool_config.data.objectStoreAuth_existingSecretAccessKeyKey }}"
+                        {{<- end >}}
                       - name: AWS_SECRET_ACCESS_KEY
+                        {{<- if .Values.kubeflow_tools.pipelines.objectStore.auth.fromEnv >}}
+                        value: ""
+                        {{<- else >}}
                         valueFrom:
                           secretKeyRef:
                             name: {{< tmpl.Exec "kubeflow_pipelines.object_store.profile.cloned_secret_name" . | quote >}}
                             key: "{{ tool_config.data.objectStoreAuth_existingSecretSecretKeyKey }}"
-                      {{<- end >}}
+                        {{<- end >}}
 
     ################################################################################
     ## Service/ml-pipeline-ui-artifact


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->

resolves: https://github.com/deployKF/deployKF/issues/75

IRSA bucket authentication did not work properly in Kubeflow Pipelines because there were [default values](https://github.com/kubeflow/pipelines/blob/2.0.0-alpha.7/backend/src/apiserver/config/config.json#L9-L13) for access-key environment variables like `OBJECTSTORECONFIG_ACCESSKEY`, `MINIO_ACCESS_KEY`, and `AWS_ACCESS_KEY_ID` which were preventing the AWS credential provider from using the Pod's IRSA authentication.

This PR simply explicitly sets all the access key env-vars to `""` when `kubeflow_tools.pipelines.objectStore.auth.fromEnv` is `false`, so they are ignored and IRSA auth is attempted.


### NOTE: this must be merged AFTER: https://github.com/deployKF/deployKF/pull/54

PS: thanks to @flaccid for testing this fix.
