### PR TITLE
fix: use 307 status for HTTP redirects

### DIFF
--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/EnvoyFilter-kubeflow-pipelines.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/EnvoyFilter-kubeflow-pipelines.yaml
@@ -137,7 +137,7 @@ spec:
                           -- redirect to new_url_path, if it was set
                           if new_url_path then
                               request_handle:respond(
-                                  { [":status"] = "302", ["location"] = new_url_path },
+                                  { [":status"] = "307", ["location"] = new_url_path },
                                     "Redirecting to correct namespace..."
                               )
                           end

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/VirtualService-https-redirect.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/VirtualService-https-redirect.yaml
@@ -29,5 +29,5 @@ spec:
       redirect:
         scheme: https
         port: {{ .Values.deployKF.gateway.ports.https | int }}
-        redirectCode: 302
+        redirectCode: 307
 {{- end }}


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
Currently, we use a `302` redirect for HTTP -> HTTPS which is breaking non-`GET` requests. This PR replaces the `302` with a `307` temporary redirect which should allow `POST` and other operations to succeed. 

References:
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections#temporary_redirections