### PR TITLE
feat: allow custom external service ports

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -648,13 +648,33 @@ deploykf_core:
     ## istio gateway configs
     ##
     gateway:
+
+      ## the name of the Gateway resource, created by deployKF
+      ##
       name: deploykf-gateway
 
+      ## the hostname that the gateway will listen on
+      ##  - subdomains of this hostname may also be used, depending on which apps are enabled
+      ##
       hostname: deploykf.example.com
+
+      ## the ports that the gateway will listen on
+      ##  - these are the "internal" ports which the gateway use, and can be different
+      ##    to the user-facing ports which the service listens on, see `gatewayService.ports`
+      ##  - you may need to set non-standard ports if you are using your own gateway service
+      ##    (`charts.istioGateway.enabled` is false) and need to avoid conflicts with existing
+      ##    services on the selected gateway deployment
+      ##
       ports:
         http: 80
         https: 443
+
+      ## gateway TLS configs
+      ##
       tls:
+
+        ## if the gateway will listen on HTTPS
+        ##
         enabled: true
 
       ## the pod labels used by the gateway to find the ingress gateway deployment
@@ -711,6 +731,16 @@ deploykf_core:
       loadBalancerIP: ""
       loadBalancerSourceRanges: []
 
+      ## the ports that the gateway service listens on
+      ##  - if unset, they default to their corresponding port under `gateway.ports`
+      ##  - these are the "public" ports which clients are expected to connect to,
+      ##    and can be different to the "internal" ports defined in `gateway.ports`
+      ##  - when using your own gateway service (`charts.istioGateway.enabled` is false)
+      ##    these values still affect the ports presented in user-facing HTTP links
+      ##
+      ports:
+        http: ~
+        https: ~
 
   ## --------------------------------------
   ##      deploykf-profiles-generator

--- a/generator/helpers/deploykf-gateway.tpl
+++ b/generator/helpers/deploykf-gateway.tpl
@@ -1,22 +1,24 @@
 ##
-## The HTTP endpoint of the gateway (hides port when set to 80)
+## The public HTTP endpoint of the gateway (hides port when set to 80)
 ##
 {{<- define "deploykf_gateway.http_endpoint" ->}}
-{{<- if eq (.Values.deploykf_core.deploykf_istio_gateway.gateway.ports.http | conv.ToString) "80" ->}}
+{{<- $http_port := .Values.deploykf_core.deploykf_istio_gateway.gatewayService.ports.http | default .Values.deploykf_core.deploykf_istio_gateway.gateway.ports.http >}}
+{{<- if eq ($http_port | conv.ToString) "80" ->}}
 {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.hostname >}}
 {{<- else ->}}
-{{< .Values.deploykf_core.deploykf_istio_gateway.gateway.hostname >}}:{{< .Values.deploykf_core.deploykf_istio_gateway.gateway.ports.http >}}
+{{< .Values.deploykf_core.deploykf_istio_gateway.gateway.hostname >}}:{{< $http_port >}}
 {{<- end ->}}
 {{<- end ->}}
 
 ##
-## The HTTPS endpoint of the gateway (hides port when set to 443)
+## The public HTTPS endpoint of the gateway (hides port when set to 443)
 ##
 {{<- define "deploykf_gateway.https_endpoint" ->}}
-{{<- if eq (.Values.deploykf_core.deploykf_istio_gateway.gateway.ports.https | conv.ToString) "443" ->}}
+{{<- $https_port := .Values.deploykf_core.deploykf_istio_gateway.gatewayService.ports.https | default .Values.deploykf_core.deploykf_istio_gateway.gateway.ports.https >}}
+{{<- if eq ($https_port | conv.ToString) "443" ->}}
 {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.hostname >}}
 {{<- else ->}}
-{{< .Values.deploykf_core.deploykf_istio_gateway.gateway.hostname >}}:{{< .Values.deploykf_core.deploykf_istio_gateway.gateway.ports.https >}}
+{{< .Values.deploykf_core.deploykf_istio_gateway.gateway.hostname >}}:{{< $https_port >}}
 {{<- end ->}}
 {{<- end ->}}
 

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/ServiceEntry-gateway.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/ServiceEntry-gateway.yaml
@@ -32,12 +32,12 @@ spec:
   location: MESH_INTERNAL
   ports:
     - name: http
-      number: {{ .Values.deployKF.gateway.ports.http | int }}
+      number: {{ .Values.deployKF.gateway.servicePorts.http | default .Values.deployKF.gateway.ports.http | int }}
       protocol: HTTP
       targetPort: {{ .Values.deployKF.gateway.ports.http | int }}
     {{- if .Values.deployKF.gateway.tls.enabled }}
     - name: https
-      number: {{ .Values.deployKF.gateway.ports.https | int }}
+      number: {{ .Values.deployKF.gateway.servicePorts.https | default .Values.deployKF.gateway.ports.https | int }}
       protocol: HTTPS
       targetPort: {{ .Values.deployKF.gateway.ports.https | int }}
     {{- end }}

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/VirtualService-https-redirect.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/VirtualService-https-redirect.yaml
@@ -27,6 +27,6 @@ spec:
           port: {{ .Values.deployKF.gateway.ports.http | int }}
       redirect:
         scheme: https
-        port: {{ .Values.deployKF.gateway.ports.https | int }}
+        port: {{ .Values.deployKF.gateway.servicePorts.https | default .Values.deployKF.gateway.ports.https | int }}
         redirectCode: 307
 {{- end }}

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/values.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/values.yaml
@@ -56,6 +56,9 @@ deployKF:
     ports:
       http: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.ports.http >}}
       https: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.ports.https >}}
+    servicePorts:
+      http: {{< .Values.deploykf_core.deploykf_istio_gateway.gatewayService.ports.http | default "~" >}}
+      https: {{< .Values.deploykf_core.deploykf_istio_gateway.gatewayService.ports.https | default "~" >}}
     tls:
       enabled: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.enabled | conv.ToBool >}}
     enableProxyProtocol: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.enableProxyProtocol >}}
@@ -104,12 +107,12 @@ gateway:
         protocol: TCP
         targetPort: 15021
       - name: http
-        port: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.ports.http >}}
+        port: {{< .Values.deploykf_core.deploykf_istio_gateway.gatewayService.ports.http | default .Values.deploykf_core.deploykf_istio_gateway.gateway.ports.http >}}
         protocol: TCP
         targetPort: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.ports.http >}}
       {{<- if .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.enabled >}}
       - name: https
-        port: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.ports.https >}}
+        port: {{< .Values.deploykf_core.deploykf_istio_gateway.gatewayService.ports.https | default .Values.deploykf_core.deploykf_istio_gateway.gateway.ports.https >}}
         protocol: TCP
         targetPort: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.ports.https >}}
       {{<- end >}}

--- a/sample-values.yaml
+++ b/sample-values.yaml
@@ -236,10 +236,22 @@ deploykf_core:
     ## istio gateway configs
     ##
     gateway:
+
+      ## the hostname that the gateway will listen on
+      ##  - subdomains of this hostname may also be used, depending on which apps are enabled
+      ##
       hostname: deploykf.example.com
+
+      ## the ports that the gateway will listen on
+      ##  - these are the "internal" ports which the gateway use, and can be different
+      ##    to the user-facing ports which the service listens on, see `gatewayService.ports`
+      ##
       ports:
         http: 8080
         https: 8443
+
+      ## the pod labels used by the gateway to find the ingress gateway deployment
+      ##
       selectorLabels:
         app: deploykf-gateway
         istio: deploykf-gateway


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
Previously we assumed the internal (on the istio gateway) and external (on the user-facing service/ingress) ports were always the same.

This PR introduces `deploykf_core.deploykf_istio_gateway.gatewayService.ports.http` and `deploykf_core.deploykf_istio_gateway.gatewayService.ports.https` which can be used to either:

1. Change the ports which the service for the embedded istio gateway listens on:
     - _(to potentially make them different from the internal gateway ports, which might help users who want to use the same istio gateway deployment for more than just deployKF)_
2. Inform deployKF about which ports are actually seen by end-users:
     - _(for users who are bringing their own gateway service, so that deployKF will correctly generate user-facing links with the correct port)_

By default, both new `deploykf_core.deploykf_istio_gateway.gatewayService.ports` values are `~` (null), and the corresponding`deploykf_core.deploykf_istio_gateway.gateway.ports` value is used (which is backward-compatible with the current behavior).