### PR TITLE
feat: allow disabling SNI matching on gateway

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -657,6 +657,13 @@ deploykf_core:
       tls:
         enabled: true
 
+        ## if the gateway will perform SNI matching on TLS connections
+        ##  - typically needs to be ~false~ when using an outer proxy that does TLS termination (like AWS ALB),
+        ##    as most cloud load-balancers don't forward the SNI for TLS connections that they terminate
+        ##    https://istio.io/v1.19/docs/ops/common-problems/network-issues/#configuring-sni-routing-when-not-sending-sni
+        ##
+        matchSNI: true
+
       ## the pod labels used by the gateway to find the ingress gateway deployment
       ##
       selectorLabels:

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/DestinationRule-notebooks-redirect.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/DestinationRule-notebooks-redirect.yaml
@@ -1,0 +1,29 @@
+{{- /* TODO: remove this once we update Kubeflow Notebooks: https://github.com/kubeflow/kubeflow/pull/6902 */ -}}
+{{- if and .Values.deployKF.gateway.tls.enabled (not .Values.deployKF.gateway.tls.matchSNI) }}
+{{- if .Values.deployKF.kubeflow.notebooks.enabled }}
+################
+## This DestinationRule tells Istio to use TLS when connecting to our notebooks-redirect service.
+## See `VirtualService/notebooks-redirect` for more details.
+################
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: notebooks-redirect
+  labels:
+    helm.sh/chart: {{ include "deploykf-istio-gateway.labels.chart" . }}
+    app.kubernetes.io/name: {{ include "deploykf-istio-gateway.labels.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  host: "notebooks-redirect.{{ .Values.deployKF.gateway.hostname }}"
+  workloadSelector:
+    matchLabels:
+     {{- toYaml .Values.deployKF.gateway.selectorLabels | nindent 6 }}
+  trafficPolicy:
+    portLevelSettings:
+      - port:
+          number: {{ .Values.deployKF.gateway.servicePorts.https | default .Values.deployKF.gateway.ports.https | int }}
+        tls:
+            mode: SIMPLE
+{{- end }}
+{{- end }}

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/DestinationRule-tensorboards-redirect.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/DestinationRule-tensorboards-redirect.yaml
@@ -1,0 +1,29 @@
+{{- /* TODO: remove this once we update Kubeflow TensorBoards: https://github.com/kubeflow/kubeflow/pull/6902 */ -}}
+{{- if and .Values.deployKF.gateway.tls.enabled (not .Values.deployKF.gateway.tls.matchSNI) }}
+{{- if .Values.deployKF.kubeflow.tensorboards.enabled }}
+################
+## This DestinationRule tells Istio to use TLS when connecting to our tensorboards-redirect service.
+## See `VirtualService/tensorboards-redirect` for more details.
+################
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: tensorboards-redirect
+  labels:
+    helm.sh/chart: {{ include "deploykf-istio-gateway.labels.chart" . }}
+    app.kubernetes.io/name: {{ include "deploykf-istio-gateway.labels.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  host: "tensorboards-redirect.{{ .Values.deployKF.gateway.hostname }}"
+  workloadSelector:
+    matchLabels:
+     {{- toYaml .Values.deployKF.gateway.selectorLabels | nindent 6 }}
+  trafficPolicy:
+    portLevelSettings:
+      - port:
+          number: {{ .Values.deployKF.gateway.servicePorts.https | default .Values.deployKF.gateway.ports.https | int }}
+        tls:
+            mode: SIMPLE
+{{- end }}
+{{- end }}

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/Gateway.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/Gateway.yaml
@@ -12,6 +12,11 @@ spec:
     {{- toYaml .Values.deployKF.gateway.selectorLabels | nindent 4 }}
   servers:
     - hosts:
+      {{- if and .Values.deployKF.gateway.tls.enabled (not .Values.deployKF.gateway.tls.matchSNI) }}
+        ## NOTE: hosts is set to "*" because most external load balancers do not forward the SNI after TLS termination
+        ##       https://istio.io/v1.19/docs/ops/common-problems/network-issues/#configuring-sni-routing-when-not-sending-sni
+        - "*"
+      {{- else }}
         ## select VirtualServices in any namespace with the deployKF hostname
         - "*/{{ .Values.deployKF.gateway.hostname }}"
         {{- if .Values.deployKF.argoWorkflows.enabled }}
@@ -23,6 +28,7 @@ spec:
         - "{{ .Values.deployKF.minio.namespace }}/minio-api.{{ .Values.deployKF.gateway.hostname }}"
         - "{{ .Values.deployKF.minio.namespace }}/minio-console.{{ .Values.deployKF.gateway.hostname }}"
         {{- end }}
+      {{- end }}
       {{- if .Values.deployKF.gateway.tls.enabled }}
       port:
         name: https

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/ServiceEntry-gateway.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/ServiceEntry-gateway.yaml
@@ -29,6 +29,18 @@ spec:
     - "minio-api.{{ .Values.deployKF.gateway.hostname }}"
     - "minio-console.{{ .Values.deployKF.gateway.hostname }}"
     {{- end }}
+
+    {{- /* TODO: remove this once we update Kubeflow Notebooks/TensorBoards: https://github.com/kubeflow/kubeflow/pull/6902 */ -}}
+    {{- if and .Values.deployKF.gateway.tls.enabled (not .Values.deployKF.gateway.tls.matchSNI) }}
+    {{- if .Values.deployKF.kubeflow.notebooks.enabled }}
+    ## NOTE: the notebooks subdomain is NOT exposed on the public gateway (see `VirtualService/notebooks-redirect`)
+    - "notebooks-redirect.{{ .Values.deployKF.gateway.hostname }}"
+    {{- end }}
+    {{- if .Values.deployKF.kubeflow.tensorboards.enabled }}
+    ## NOTE: the tensorboards subdomain is NOT exposed on the public gateway (see `VirtualService/tensorboards-redirect`)
+    - "tensorboards-redirect.{{ .Values.deployKF.gateway.hostname }}"
+    {{- end }}
+    {{- end }}
   location: MESH_INTERNAL
   ports:
     - name: http

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/VirtualService-notebooks-redirect.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/VirtualService-notebooks-redirect.yaml
@@ -2,13 +2,12 @@
 {{- if and .Values.deployKF.gateway.tls.enabled (not .Values.deployKF.gateway.tls.matchSNI) }}
 {{- if .Values.deployKF.kubeflow.notebooks.enabled }}
 ################
-## This VirtualService is a workaround for Kubeflow Notebooks creating VirtualServices with "*" for `spec.hosts`.
-##
-## The problem is that our dashboard VirtualService sets a specific `sepc.hosts` and matches all paths under `/`.
-## Because that is a "more specific match", all notebook traffic is mistakenly routed to the dashboard.
-##
 ## This VirtualService matches all `/notebook/` paths and proxies the traffic back to the gateway with a different hostname.
 ## Also see: `ServiceEntry/deploykf-istio-gateway` and `DestinationRule/notebooks-redirect`
+##
+## This is a workaround for Kubeflow Notebooks creating VirtualServices with "*" for `spec.hosts`.
+## The problem is that our dashboard VirtualService sets a specific `sepc.hosts` and matches all paths under `/`.
+## Because that is a "more specific match", all notebook traffic is mistakenly routed to the dashboard.
 ################
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/VirtualService-notebooks-redirect.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/VirtualService-notebooks-redirect.yaml
@@ -1,0 +1,40 @@
+{{- /* TODO: remove this once we update Kubeflow Notebooks: https://github.com/kubeflow/kubeflow/pull/6902 */ -}}
+{{- if and .Values.deployKF.gateway.tls.enabled (not .Values.deployKF.gateway.tls.matchSNI) }}
+{{- if .Values.deployKF.kubeflow.notebooks.enabled }}
+################
+## This VirtualService is a workaround for Kubeflow Notebooks creating VirtualServices with "*" for `spec.hosts`.
+##
+## The problem is that our dashboard VirtualService sets a specific `sepc.hosts` and matches all paths under `/`.
+## Because that is a "more specific match", all notebook traffic is mistakenly routed to the dashboard.
+##
+## This VirtualService matches all `/notebook/` paths and proxies the traffic back to the gateway with a different hostname.
+## Also see: `ServiceEntry/deploykf-istio-gateway` and `DestinationRule/notebooks-redirect`
+################
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: notebooks-redirect
+  labels:
+    helm.sh/chart: {{ include "deploykf-istio-gateway.labels.chart" . }}
+    app.kubernetes.io/name: {{ include "deploykf-istio-gateway.labels.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  gateways:
+    - {{ .Release.Namespace }}/{{ .Values.deployKF.gateway.name }}
+  hosts:
+    - {{ .Values.deployKF.gateway.hostname | quote }}
+  http:
+    - match:
+        - uri:
+            prefix: /notebook/
+      rewrite:
+        {{- $public_port := .Values.deployKF.gateway.servicePorts.https | default .Values.deployKF.gateway.ports.https }}
+        authority: "notebooks-redirect.{{ .Values.deployKF.gateway.hostname }}:{{ $public_port }}"
+      route:
+        - destination:
+            host: "notebooks-redirect.{{ .Values.deployKF.gateway.hostname }}"
+            port:
+              number: {{ $public_port }}
+{{- end }}
+{{- end }}

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/VirtualService-tensorboards-redirect.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/VirtualService-tensorboards-redirect.yaml
@@ -2,13 +2,12 @@
 {{- if and .Values.deployKF.gateway.tls.enabled (not .Values.deployKF.gateway.tls.matchSNI) }}
 {{- if .Values.deployKF.kubeflow.tensorboards.enabled }}
 ################
-## This VirtualService is a workaround for Kubeflow TensorBoards creating VirtualServices with "*" for `spec.hosts`.
-##
-## The problem is that our dashboard VirtualService sets a specific `sepc.hosts` and matches all paths under `/`.
-## Because that is a "more specific match", all tensorboard traffic is mistakenly routed to the dashboard.
-##
 ## This VirtualService matches all `/tensorboard/` paths and proxies the traffic back to the gateway with a different hostname.
 ## Also see: `ServiceEntry/deploykf-istio-gateway` and `DestinationRule/tensorboards-redirect`
+##
+## This is a workaround for Kubeflow TensorBoards creating VirtualServices with "*" for `spec.hosts`.
+## The problem is that our dashboard VirtualService sets a specific `sepc.hosts` and matches all paths under `/`.
+## Because that is a "more specific match", all tensorboard traffic is mistakenly routed to the dashboard.
 ################
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/VirtualService-tensorboards-redirect.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/VirtualService-tensorboards-redirect.yaml
@@ -1,0 +1,40 @@
+{{- /* TODO: remove this once we update Kubeflow TensorBoards: https://github.com/kubeflow/kubeflow/pull/6902 */ -}}
+{{- if and .Values.deployKF.gateway.tls.enabled (not .Values.deployKF.gateway.tls.matchSNI) }}
+{{- if .Values.deployKF.kubeflow.tensorboards.enabled }}
+################
+## This VirtualService is a workaround for Kubeflow TensorBoards creating VirtualServices with "*" for `spec.hosts`.
+##
+## The problem is that our dashboard VirtualService sets a specific `sepc.hosts` and matches all paths under `/`.
+## Because that is a "more specific match", all tensorboard traffic is mistakenly routed to the dashboard.
+##
+## This VirtualService matches all `/tensorboard/` paths and proxies the traffic back to the gateway with a different hostname.
+## Also see: `ServiceEntry/deploykf-istio-gateway` and `DestinationRule/tensorboards-redirect`
+################
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: tensorboards-redirect
+  labels:
+    helm.sh/chart: {{ include "deploykf-istio-gateway.labels.chart" . }}
+    app.kubernetes.io/name: {{ include "deploykf-istio-gateway.labels.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  gateways:
+    - {{ .Release.Namespace }}/{{ .Values.deployKF.gateway.name }}
+  hosts:
+    - {{ .Values.deployKF.gateway.hostname | quote }}
+  http:
+    - match:
+        - uri:
+            prefix: /tensorboard/
+      rewrite:
+        {{- $public_port := .Values.deployKF.gateway.servicePorts.https | default .Values.deployKF.gateway.ports.https }}
+        authority: "tensorboards-redirect.{{ .Values.deployKF.gateway.hostname }}:{{ $public_port }}"
+      route:
+        - destination:
+            host: "tensorboards-redirect.{{ .Values.deployKF.gateway.hostname }}"
+            port:
+              number: {{ $public_port }}
+{{- end }}
+{{- end }}

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/values.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/values.yaml
@@ -27,6 +27,10 @@ deployKF:
         defaultPipelineRoot: {{< .Values.kubeflow_tools.pipelines.kfpV2.defaultPipelineRoot | quote >}}
       cache:
         namespaceRedirect: {{< .Values.kubeflow_tools.pipelines.cache.namespaceRedirect | conv.ToBool >}}
+    notebooks:
+      enabled: {{< .Values.kubeflow_tools.notebooks.enabled | conv.ToBool >}}
+    tensorboards:
+      enabled: {{< .Values.kubeflow_tools.tensorboards.enabled | conv.ToBool >}}
 
   certManager:
     clusterIssuer:
@@ -57,6 +61,7 @@ deployKF:
       https: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.ports.https >}}
     tls:
       enabled: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.enabled | conv.ToBool >}}
+      matchSNI: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.matchSNI | conv.ToBool >}}
     enableProxyProtocol: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.enableProxyProtocol >}}
     xffNumTrustedHops: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.xffNumTrustedHops >}}
     emailToLowercase: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.emailToLowercase | conv.ToBool >}}

--- a/generator/templates/manifests/kubeflow-tools/katib/patches/patch-katib-ui-virtualservice.yaml
+++ b/generator/templates/manifests/kubeflow-tools/katib/patches/patch-katib-ui-virtualservice.yaml
@@ -4,5 +4,7 @@ metadata:
   name: katib-ui
   namespace: kubeflow
 spec:
+  hosts:
+    - {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.hostname | quote >}}
   gateways:
     - {{< .Values.deploykf_core.deploykf_istio_gateway.namespace >}}/{{< .Values.deploykf_core.deploykf_istio_gateway.gateway.name >}}

--- a/generator/templates/manifests/kubeflow-tools/notebooks/jupyter-web-app/patches/patch-jupyter-web-app-virtualservice.yaml
+++ b/generator/templates/manifests/kubeflow-tools/notebooks/jupyter-web-app/patches/patch-jupyter-web-app-virtualservice.yaml
@@ -4,5 +4,7 @@ metadata:
   name: jupyter-web-app-jupyter-web-app
   namespace: kubeflow
 spec:
+  hosts:
+    - {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.hostname | quote >}}
   gateways:
     - {{< .Values.deploykf_core.deploykf_istio_gateway.namespace >}}/{{< .Values.deploykf_core.deploykf_istio_gateway.gateway.name >}}

--- a/generator/templates/manifests/kubeflow-tools/pipelines/patches/patch-metadata-grpc-virtualservice.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/patches/patch-metadata-grpc-virtualservice.yaml
@@ -4,5 +4,7 @@ metadata:
   name: metadata-grpc
   namespace: kubeflow
 spec:
+  hosts:
+    - {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.hostname | quote >}}
   gateways:
     - {{< .Values.deploykf_core.deploykf_istio_gateway.namespace >}}/{{< .Values.deploykf_core.deploykf_istio_gateway.gateway.name >}}

--- a/generator/templates/manifests/kubeflow-tools/pipelines/patches/patch-ml-pipeline-ui-virtualservice.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/patches/patch-ml-pipeline-ui-virtualservice.yaml
@@ -4,6 +4,8 @@ metadata:
   name: ml-pipeline-ui
   namespace: kubeflow
 spec:
+  hosts:
+    - {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.hostname | quote >}}
   gateways:
     - {{< .Values.deploykf_core.deploykf_istio_gateway.namespace >}}/{{< .Values.deploykf_core.deploykf_istio_gateway.gateway.name >}}
   http:

--- a/generator/templates/manifests/kubeflow-tools/tensorboards/tensorboards-web-app/patches/patch-tensorboards-web-app-virtualservice.yaml
+++ b/generator/templates/manifests/kubeflow-tools/tensorboards/tensorboards-web-app/patches/patch-tensorboards-web-app-virtualservice.yaml
@@ -4,5 +4,7 @@ metadata:
   name: tensorboards-web-app-tensorboards-web-app
   namespace: kubeflow
 spec:
+  hosts:
+    - {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.hostname | quote >}}
   gateways:
     - {{< .Values.deploykf_core.deploykf_istio_gateway.namespace >}}/{{< .Values.deploykf_core.deploykf_istio_gateway.gateway.name >}}

--- a/generator/templates/manifests/kubeflow-tools/volumes/volumes-web-app/patches/patch-volumes-web-app-virtualservice.yaml
+++ b/generator/templates/manifests/kubeflow-tools/volumes/volumes-web-app/patches/patch-volumes-web-app-virtualservice.yaml
@@ -4,5 +4,7 @@ metadata:
   name: volumes-web-app-volumes-web-app
   namespace: kubeflow
 spec:
+  hosts:
+    - {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.hostname | quote >}}
   gateways:
     - {{< .Values.deploykf_core.deploykf_istio_gateway.namespace >}}/{{< .Values.deploykf_core.deploykf_istio_gateway.gateway.name >}}


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR allows users to disable SNI matching on the gateway by adding a new value `deploykf_core.deploykf_istio_gateway.gateway.tls.matchSNI` (which defaults to `true`).

Users may need to disable SNI matching when they are putting the deployKF gateway behind their own proxy which is doing TLS Termination, as most cloud proxies will not forward the original requests SNI to the backend system (e.g. AWS ALB). This is a very common issue, which even has its own [Istio documentation page](https://istio.io/v1.19/docs/ops/common-problems/network-issues/#configuring-sni-routing-when-not-sending-sni).

As part of this PR, we needed to work around the fact that _Kubeflow Notebooks_ and _Kubeflow TensorBoards_ currently always set their VirtualServices `spec.hosts` to `*`. This is a problem because our dashboard's VirtualService matches all HTTP paths on the domain, and Envoy/Istio treats that route as "more specific" and so more preferred than the `*` notebook route, meaning that all notebook traffic incorrectly ends up at the dashboard pods.

As a temporary measure until upstream https://github.com/kubeflow/kubeflow/pull/6902 is merged and released, we resolve this issue by having a VirtualService that matches all `/notebook/` paths which internally proxies the requests so that they have a different host/authority (`notebooks-redirect.deploykf.example.com`), which makes that request not match the dashboard route, and so end up at the notebook.

Note that `notebooks-redirect.deploykf.example.com` is NEVER served on the public-facing part of the gateway, and is only in-mesh (defined in the  ServiceEntry called `deploykf-istio-gateway`), so there is no need to create a public DNS entry for it.

### NOTE: this must be merged AFTER: https://github.com/deployKF/deployKF/pull/82