### PR TITLE
fix: issues preventing deployment on Azure AKS

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -63,6 +63,23 @@ argocd:
 
 ## --------------------------------------------------------------------------------
 ##
+##                                    kubernetes
+##
+## --------------------------------------------------------------------------------
+kubernetes:
+
+  ## configs specific to Azure Kubernetes
+  ##
+  azure:
+
+    ## apply workarounds for the AKS Admissions Enforcer
+    ##  - https://github.com/deployKF/deployKF/issues/61
+    ##
+    admissionsEnforcerFix: false
+
+
+## --------------------------------------------------------------------------------
+##
 ##                              deploykf-dependencies
 ##
 ## --------------------------------------------------------------------------------

--- a/generator/templates/argocd/applications/deploykf-dependencies/istio.yaml
+++ b/generator/templates/argocd/applications/deploykf-dependencies/istio.yaml
@@ -44,3 +44,14 @@ spec:
       name: istiod-default-validator
       jqPathExpressions:
         - ".webhooks[]?.failurePolicy"
+    {{<- if .Values.kubernetes.azure.admissionsEnforcerFix >}}
+    ## azure aks admissions enforcer fix
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      jqPathExpressions:
+        - ".webhooks[]?.namespaceSelector"
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      jqPathExpressions:
+        - ".webhooks[]?.namespaceSelector"
+    {{<- end >}}

--- a/generator/templates/argocd/namespaces/kubeflow-tools/kubeflow.yaml
+++ b/generator/templates/argocd/namespaces/kubeflow-tools/kubeflow.yaml
@@ -3,6 +3,5 @@ kind: Namespace
 metadata:
   name: kubeflow
   labels:
-    control-plane: kubeflow
     istio-injection: enabled
     deploykf.github.io/inject-root-ca-cert: enabled

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/FORK.md
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/FORK.md
@@ -7,6 +7,7 @@ __The changes made in this fork are:__
 - the chart version has been suffixed with `-deploykf`, to avoid confusion with the upstream chart
 - added the `app.deploymentAnnotations` value (used to set `argocd.argoproj.io/sync-wave` to resolve race conditions on sync)
 - added the `app.certificateAnnotations` value (used to set `argocd.argoproj.io/sync-wave` to resolve race conditions on sync)
+- added the `app.webhook.validatingWebhookConfigurationAnnotations` value (used to work around Azure AKS Admissions Enforcer)
 
 To aid in the maintenance of this fork, all places where changes have been made are wrapped as follows:
 

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/webhook.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/templates/webhook.yaml
@@ -28,6 +28,9 @@ metadata:
 {{ include "trust-manager.labels" . | indent 4 }}
   annotations:
     cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "trust-manager.name" . }}"
+    {{- if .Values.app.webhook.validatingWebhookConfigurationAnnotations }}
+    {{- toYaml .Values.app.webhook.validatingWebhookConfigurationAnnotations | nindent 4 }}
+    {{- end }}
 
 webhooks:
   - name: trust.cert-manager.io

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/values.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/forks/trust-manager/values.yaml
@@ -74,6 +74,11 @@ app:
     service:
       type: ClusterIP
 
+    #################### BEGIN CHANGE ####################
+    # -- Annotations for the trust-manager Webhook
+    validatingWebhookConfigurationAnnotations: {}
+    ##################### END CHANGE #####################
+
   securityContext:
     # -- If false, disables the default seccomp profile, which might be required to run on certain platforms
     seccompProfileEnabled: true

--- a/generator/templates/manifests/deploykf-dependencies/cert-manager/values.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/cert-manager/values.yaml
@@ -58,6 +58,15 @@ cert-manager:
       {{<- end >}}
       pullPolicy: {{< .Values.deploykf_dependencies.cert_manager.images.certManagerWebhook.pullPolicy | quote >}}
 
+    {{<- if .Values.kubernetes.azure.admissionsEnforcerFix >}}
+    ## azure aks admissions enforcer fix
+    ## https://github.com/cert-manager/cert-manager/issues/4114
+    validatingWebhookConfigurationAnnotations:
+      "admissions.enforcer/disabled": "true"
+    mutatingWebhookConfigurationAnnotations:
+      "admissions.enforcer/disabled": "true"
+    {{<- end >}}
+
   cainjector:
     enabled: true
     replicaCount: 1
@@ -139,3 +148,10 @@ trust-manager:
 
     trust:
       namespace: {{< .Values.deploykf_dependencies.cert_manager.namespace | quote >}}
+
+    {{<- if .Values.kubernetes.azure.admissionsEnforcerFix >}}
+    ## azure aks admissions enforcer fix
+    webhook:
+      validatingWebhookConfigurationAnnotations:
+        "admissions.enforcer/disabled": "true"
+    {{<- end >}}

--- a/generator/templates/manifests/deploykf-dependencies/kyverno/values.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/kyverno/values.yaml
@@ -49,6 +49,15 @@ deployKF:
 kyverno:
   fullnameOverride: kyverno
 
+  {{<- if .Values.kubernetes.azure.admissionsEnforcerFix >}}
+  ## Kyverno configurations
+  config:
+    ## azure aks admissions enforcer fix
+    ## https://kyverno.io/docs/installation/platform-notes/#notes-for-aks-users
+    webhookAnnotations:
+      "admissions.enforcer/disabled": "true"
+  {{<- end >}}
+
   ## Kyverno feature flags
   features:
 

--- a/generator/templates/manifests/kubeflow-tools/katib/kustomization.yaml
+++ b/generator/templates/manifests/kubeflow-tools/katib/kustomization.yaml
@@ -31,6 +31,8 @@ patchesStrategicMerge:
   - patches/patch-katib-ui-authorizationpolicy.yaml
   - patches/patch-katib-ui-deployment.yaml
   - patches/patch-katib-ui-virtualservice.yaml
+  - patches/patch-katib-mutatingwebhook.yaml
+  - patches/patch-katib-validatingwebhook.yaml
 
   ## removals
   - patches/removals/mysql-resources.yaml

--- a/generator/templates/manifests/kubeflow-tools/katib/patches/patch-katib-mutatingwebhook.yaml
+++ b/generator/templates/manifests/kubeflow-tools/katib/patches/patch-katib-mutatingwebhook.yaml
@@ -1,0 +1,9 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: katib.kubeflow.org
+  {{<- if .Values.kubernetes.azure.admissionsEnforcerFix >}}
+  annotations:
+    ## azure aks admissions enforcer fix
+    "admissions.enforcer/disabled": "true"
+  {{<- end >}}

--- a/generator/templates/manifests/kubeflow-tools/katib/patches/patch-katib-validatingwebhook.yaml
+++ b/generator/templates/manifests/kubeflow-tools/katib/patches/patch-katib-validatingwebhook.yaml
@@ -1,0 +1,9 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: katib.kubeflow.org
+  {{<- if .Values.kubernetes.azure.admissionsEnforcerFix >}}
+  annotations:
+    ## azure aks admissions enforcer fix
+    "admissions.enforcer/disabled": "true"
+  {{<- end >}}

--- a/generator/templates/manifests/kubeflow-tools/pipelines/kustomization.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/kustomization.yaml
@@ -47,6 +47,7 @@ resources:
 
 patchesStrategicMerge:
   - patches/patch-cache-server-deployment.yaml
+  - patches/patch-cache-server-mutatingwebhook.yaml
   - patches/patch-metadata-grpc-deployment-deployment.yaml
   - patches/patch-metadata-grpc-virtualservice.yaml
   - patches/patch-ml-pipeline-deployment.yaml

--- a/generator/templates/manifests/kubeflow-tools/pipelines/patches/patch-cache-server-mutatingwebhook.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/patches/patch-cache-server-mutatingwebhook.yaml
@@ -1,0 +1,9 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: cache-webhook-kubeflow
+  {{<- if .Values.kubernetes.azure.admissionsEnforcerFix >}}
+  annotations:
+    ## azure aks admissions enforcer fix
+    "admissions.enforcer/disabled": "true"
+  {{<- end >}}

--- a/generator/templates/manifests/kubeflow-tools/poddefaults-webhook/kustomization.yaml
+++ b/generator/templates/manifests/kubeflow-tools/poddefaults-webhook/kustomization.yaml
@@ -14,6 +14,9 @@ resources:
   - resources/extra-manifests.yaml
   {{<- end >}}
 
+patchesStrategicMerge:
+  - patches/patch-mutatingwebhook.yaml
+
 images:
   - name: docker.io/kubeflownotebookswg/poddefaults-webhook
     newName: {{< .Values.kubeflow_tools.poddefaults_webhook.images.poddefaultsWebhook.repository | quote >}}

--- a/generator/templates/manifests/kubeflow-tools/poddefaults-webhook/patches/patch-mutatingwebhook.yaml
+++ b/generator/templates/manifests/kubeflow-tools/poddefaults-webhook/patches/patch-mutatingwebhook.yaml
@@ -1,0 +1,9 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: admission-webhook-mutating-webhook-configuration
+  {{<- if .Values.kubernetes.azure.admissionsEnforcerFix >}}
+  annotations:
+    ## azure aks admissions enforcer fix
+    "admissions.enforcer/disabled": "true"
+  {{<- end >}}


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
closes: https://github.com/deployKF/deployKF/issues/61

This PR allows deployKF to be used on Azure AKS by resolving issues with the [Azure ASK - Admission Enforcer](https://learn.microsoft.com/en-us/azure/aks/faq#can-admission-controller-webhooks-impact-kube-system-and-internal-aks-namespaces):
- Removes the `control-plane: kubeflow` label from the `kubeflow` namespace.
- Introduces the `kubernetes.azure.admissionsEnforcerFix` value, which when set to `true`, applies the `"admissions.enforcer/disabled": "true"` annotation to webhooks in the following components:

    - __deploykf-dependencies:__
        - Cert-Manager / Trust-Manager
        - Istio:
            - Because we use the Istio helm chart, there is no way to apply these labels, so we instead just ignore diffs under `namespaceSelector` in ArgoCD, so that it will at least not show as "out of sync" perpetually.
        - Kyverno
    - __kubeflow-tools:__
        - Pipelines
        - Katib
        - PodDefaults-Webhook