### PR TITLE
feat: allow disabling HTTPS redirect

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -674,8 +674,15 @@ deploykf_core:
       tls:
 
         ## if the gateway will listen on HTTPS
+        ##  - must ALWAYS be true (even if an outer proxy is doing its own TLS termination)
         ##
         enabled: true
+
+        ## if browser clients use HTTPS when connecting to the gateway
+        ##  - determines the protocol of links and cookies presented to client browsers,
+        ##    should ~only~ be false if your end-users connect over HTTP, which is NOT recommended
+        ##
+        clientsUseHttps: true
 
         ## if the gateway will perform SNI matching on TLS connections
         ##  - typically needs to be ~false~ when using an outer proxy that does TLS termination (like AWS ALB),
@@ -683,6 +690,18 @@ deploykf_core:
         ##    https://istio.io/v1.19/docs/ops/common-problems/network-issues/#configuring-sni-routing-when-not-sending-sni
         ##
         matchSNI: true
+
+        ## if the gateway will redirect all HTTP requests to HTTPS
+        ##  - when false, the gateway will allow both HTTP and HTTPS connections
+        ##  - [WARNING] you should ~only~ set this to false if you have an outer proxy doing TLS termination
+        ##              that is ~unable~ to communicate with the gateway over HTTPS, and you don't care about
+        ##              the security of the connections between your outer proxy and the gateway
+        ##  - [WARNING] allowing HTTP connections will ~increase~ the load on your gateway pods,
+        ##              this is because HTTP is implemented by proxying to HTTPS internally
+        ##              (this strange behavior is required because of an Istio limitation and
+        ##               the way we apply authentication to routes with EnvoyFilters)
+        ##
+        redirect: true
 
       ## the pod labels used by the gateway to find the ingress gateway deployment
       ##

--- a/generator/helpers/check-values--incompatible-configs.tpl
+++ b/generator/helpers/check-values--incompatible-configs.tpl
@@ -20,6 +20,23 @@
 
 ## --------------------------------------------------------------------------------
 ##
+##                                  deploykf-core
+##
+## --------------------------------------------------------------------------------
+
+## --------------------------------------
+##         deploykf-istio-gateway
+## --------------------------------------
+{{<- if not .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.enabled >}}
+  {{< fail "`deploykf_core.deploykf_istio_gateway.gateway.tls.enabled` must be true (TIP: to allow HTTP connections on the gateway, set `deploykf_core.deploykf_istio_gateway.gateway.tls.redirect` to false)" >}}
+{{<- end >}}
+
+{{<- if and .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.redirect (not .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.clientsUseHttps) >}}
+  {{< fail "`deploykf_core.deploykf_istio_gateway.gateway.tls.clientsUseHttps` must be true if `deploykf_core.deploykf_istio_gateway.gateway.tls.redirect` is true" >}}
+{{<- end >}}
+
+## --------------------------------------------------------------------------------
+##
 ##                              kubeflow-dependencies
 ##
 ## --------------------------------------------------------------------------------

--- a/generator/templates/manifests/deploykf-core/deploykf-auth/templates/dex/Secret-config.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-auth/templates/dex/Secret-config.yaml
@@ -5,7 +5,7 @@ The gomplate templates are provided by the `entrypoint.sh` script of the dex con
 and are seperate from deploKF's gomplate templates.
 */}}
 ## the base path of dex and the external name of the OpenID Connect service
-{{- if .Values.deployKF.gateway.tls.enabled }}
+{{- if .Values.deployKF.gateway.tls.clientsUseHttps }}
 issuer: "https://{{ .Values.deployKF_helpers.deploykf_gateway.https_endpoint }}/dex"
 {{- else }}
 issuer: "http://{{ .Values.deployKF_helpers.deploykf_gateway.http_endpoint }}/dex"
@@ -76,7 +76,7 @@ staticClients:
     secret: {{ .Values.dex.clients.oauth2Proxy.clientSecret.value | quote }}
     {{- end }}
     redirectURIs:
-      {{- if .Values.deployKF.gateway.tls.enabled }}
+      {{- if .Values.deployKF.gateway.tls.clientsUseHttps }}
       - "https://{{ .Values.deployKF_helpers.deploykf_gateway.https_endpoint }}/oauth2/callback"
       {{- else }}
       - "http://{{ .Values.deployKF_helpers.deploykf_gateway.http_endpoint }}/oauth2/callback"
@@ -92,7 +92,7 @@ staticClients:
     secret: {{ .Values.dex.clients.minioConsole.clientSecret.value | quote }}
     {{- end }}
     redirectURIs:
-    {{- if .Values.deployKF.gateway.tls.enabled }}
+    {{- if .Values.deployKF.gateway.tls.clientsUseHttps }}
       - "https://minio-console.{{ .Values.deployKF_helpers.deploykf_gateway.https_endpoint }}/oauth_callback"
     {{- else }}
       - "http://minio-console.{{ .Values.deployKF_helpers.deploykf_gateway.http_endpoint }}/oauth_callback"
@@ -109,7 +109,7 @@ staticClients:
     secret: {{ .Values.dex.clients.argoServer.clientSecret.value | quote }}
     {{- end }}
     redirectURIs:
-    {{- if .Values.deployKF.gateway.tls.enabled }}
+    {{- if .Values.deployKF.gateway.tls.clientsUseHttps }}
       - "https://argo-server.{{ .Values.deployKF_helpers.deploykf_gateway.https_endpoint }}/oauth2/callback"
     {{- else }}
       - "http://argo-server.{{ .Values.deployKF_helpers.deploykf_gateway.http_endpoint }}/oauth2/callback"

--- a/generator/templates/manifests/deploykf-core/deploykf-auth/templates/oauth2-proxy/Secret-config.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-auth/templates/oauth2-proxy/Secret-config.yaml
@@ -67,7 +67,7 @@ oidc_groups_claim = "groups"
 ##       https://dexidp.io/docs/connectors/
 scope = "openid email groups profile offline_access"
 
-{{ if .Values.deployKF.gateway.tls.enabled -}}
+{{ if .Values.deployKF.gateway.tls.clientsUseHttps -}}
 oidc_issuer_url = "https://{{ .Values.deployKF_helpers.deploykf_gateway.https_endpoint }}/dex"
 redirect_url = "https://{{ .Values.deployKF_helpers.deploykf_gateway.https_endpoint }}/oauth2/callback"
 {{- else }}
@@ -109,7 +109,7 @@ cookie_domains = [
 ]
 cookie_expire = {{ .Values.oauth2Proxy.cookie.expire | quote }}
 cookie_refresh = {{ .Values.oauth2Proxy.cookie.refresh | quote }}
-{{- if .Values.deployKF.gateway.tls.enabled }}
+{{- if .Values.deployKF.gateway.tls.clientsUseHttps }}
 cookie_secure = true
 {{- else }}
 cookie_secure = false

--- a/generator/templates/manifests/deploykf-core/deploykf-auth/values.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-auth/values.yaml
@@ -37,6 +37,7 @@ deployKF:
     hostname: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.hostname | quote >}}
     tls:
       enabled: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.enabled | conv.ToBool >}}
+      clientsUseHttps: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.clientsUseHttps | conv.ToBool >}}
 
 
 ########################################

--- a/generator/templates/manifests/deploykf-core/deploykf-dashboard/values.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-dashboard/values.yaml
@@ -107,7 +107,7 @@ centralDashboard:
         iframe: false
         text: Argo Server
         icon: settings-input-composite
-        {{<- if .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.enabled >}}
+        {{<- if .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.clientsUseHttps >}}
         link: "https://argo-server.{{< tmpl.Exec "deploykf_gateway.https_endpoint" . >}}"
         {{<- else >}}
         link: "http://argo-server.{{< tmpl.Exec "deploykf_gateway.http_endpoint" . >}}"
@@ -118,7 +118,7 @@ centralDashboard:
         iframe: false
         text: Minio Console
         icon: cloud
-        {{<- if .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.enabled >}}
+        {{<- if .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.clientsUseHttps >}}
         link: "https://minio-console.{{< tmpl.Exec "deploykf_gateway.https_endpoint" . >}}"
         {{<- else >}}
         link: "http://minio-console.{{< tmpl.Exec "deploykf_gateway.http_endpoint" . >}}"

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/DestinationRule-https-redirect.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/DestinationRule-https-redirect.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.deployKF.gateway.tls.enabled (not .Values.deployKF.gateway.tls.redirect) }}
+################
+## This DestinationRule tells Istio to use TLS when connecting to our https-redirect service.
+## See `VirtualService/https-redirect` for more details.
+################
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: https-redirect
+  labels:
+    helm.sh/chart: {{ include "deploykf-istio-gateway.labels.chart" . }}
+    app.kubernetes.io/name: {{ include "deploykf-istio-gateway.labels.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  host: {{ .Values.deployKF.gateway.hostname | quote }}
+  workloadSelector:
+    matchLabels:
+     {{- toYaml .Values.deployKF.gateway.selectorLabels | nindent 6 }}
+  trafficPolicy:
+    portLevelSettings:
+      - port:
+          number: {{ .Values.deployKF.gateway.servicePorts.https | default .Values.deployKF.gateway.ports.https | int }}
+        tls:
+            mode: SIMPLE
+            sni: {{ .Values.deployKF.gateway.hostname | quote }}
+{{- end }}

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/EnvoyFilter-ext-authz.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/EnvoyFilter-ext-authz.yaml
@@ -11,6 +11,16 @@
 ## We disable the filters for Gateways/Routes that do not need them, or which would cause a redirect loop.
 ## Routes from the user's other gateways on the same deployment should not be affected.
 ################
+{{- /* the listener port-numbers to apply these patches to */ -}}
+{{- /* NOTE: Istio does NOT allow `match.routeConfiguration.gateway` to be used on HTTP routes (https://github.com/istio/istio/issues/46459),
+       so if HTTP routes are needed (when `deploykf_core.deploykf_istio_gateway.gateway.tls.redirect` is false),
+       they are implemented by internally proxying them to the HTTPS routes (see `VirtualService/https-redirect`) */ -}}
+{{- $listner_port_numbers := list }}
+{{- if .Values.deployKF.gateway.tls.enabled }}
+  {{- $listner_port_numbers = .Values.deployKF.gateway.ports.https | int | append $listner_port_numbers }}
+{{- end }}
+
+{{- /* the virtual route-names which should NOT be behind our authentication */ -}}
 {{- $disable_auth_routes := list }}
 {{- $disable_auth_routes = "dex-route" | append $disable_auth_routes }}
 {{- $disable_auth_routes = "oauth2-proxy-route" | append $disable_auth_routes }}
@@ -38,15 +48,14 @@ spec:
     ################################################################################
     ## FILTER 1 - Set DynamicMetadata for requests that need to be authenticated
     ################################################################################
+    {{- range $port_number := $listner_port_numbers }}
+    {{- "\n" }}
+    ## for port {{ $port_number }}
     - applyTo: HTTP_FILTER
       match:
         context: GATEWAY
         listener:
-          {{- if .Values.deployKF.gateway.tls.enabled }}
-          portNumber: {{ .Values.deployKF.gateway.ports.https | int }}
-          {{- else }}
-          portNumber: {{ .Values.deployKF.gateway.ports.http | int }}
-          {{- end }}
+          portNumber: {{ $port_number }}
           filterChain:
             filter:
               name: envoy.filters.network.http_connection_manager
@@ -82,19 +91,19 @@ spec:
                         true
                       )
                   end
+    {{- end }}
 
     ################################################################################
     ## FILTER 2 - Set JWT `Authorization` header from oauth2-proxy
     ################################################################################
+    {{- range $port_number := $listner_port_numbers }}
+    {{- "\n" }}
+    ## for port {{ $port_number }}
     - applyTo: HTTP_FILTER
       match:
         context: GATEWAY
         listener:
-          {{- if .Values.deployKF.gateway.tls.enabled }}
-          portNumber: {{ .Values.deployKF.gateway.ports.https | int }}
-          {{- else }}
-          portNumber: {{ .Values.deployKF.gateway.ports.http | int }}
-          {{- end }}
+          portNumber: {{ $port_number }}
           filterChain:
             filter:
               name: envoy.filters.network.http_connection_manager
@@ -125,8 +134,8 @@ spec:
             ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-httpservice
             http_service:
               server_uri:
-                uri: "http://oauth2-proxy.{{ .Values.deployKF.auth.namespace }}.svc.{{ .Values.deployKF.clusterDomain }}:4180"
-                cluster: "outbound|4180||oauth2-proxy.{{ .Values.deployKF.auth.namespace }}.svc.{{ .Values.deployKF.clusterDomain }}"
+                uri: "http://oauth2-proxy.{{ $.Values.deployKF.auth.namespace }}.svc.{{ $.Values.deployKF.clusterDomain }}:4180"
+                cluster: "outbound|4180||oauth2-proxy.{{ $.Values.deployKF.auth.namespace }}.svc.{{ $.Values.deployKF.clusterDomain }}"
                 timeout: 5s
 
               ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#extensions-filters-http-ext-authz-v3-authorizationrequest
@@ -169,19 +178,19 @@ spec:
                     ## NOTE: this is needed for oauth2-proxy cookie_refresh to work
                     - exact: set-cookie
                       ignore_case: true
+    {{- end }}
 
     ################################################################################
     ## FILTER 3 - Verify JWT, and path access by JWT audience
     ################################################################################
+    {{- range $port_number := $listner_port_numbers }}
+    {{- "\n" }}
+    ## for port {{ $port_number }}
     - applyTo: HTTP_FILTER
       match:
         context: GATEWAY
         listener:
-          {{- if .Values.deployKF.gateway.tls.enabled }}
-          portNumber: {{ .Values.deployKF.gateway.ports.https | int }}
-          {{- else }}
-          portNumber: {{ .Values.deployKF.gateway.ports.http | int }}
-          {{- end }}
+          portNumber: {{ $port_number }}
           filterChain:
             filter:
               name: envoy.filters.network.http_connection_manager
@@ -202,17 +211,17 @@ spec:
               ## provider for the deployKF dex server
               deploykf_dex:
                 ## must match the issuer presented by the dex server
-                {{- if .Values.deployKF.gateway.tls.enabled }}
-                issuer: "https://{{ .Values.deployKF_helpers.deploykf_gateway.https_endpoint }}/dex"
+                {{- if $.Values.deployKF.gateway.tls.clientsUseHttps }}
+                issuer: "https://{{ $.Values.deployKF_helpers.deploykf_gateway.https_endpoint }}/dex"
                 {{- else }}
-                issuer: "http://{{ .Values.deployKF_helpers.deploykf_gateway.http_endpoint }}/dex"
+                issuer: "http://{{ $.Values.deployKF_helpers.deploykf_gateway.http_endpoint }}/dex"
                 {{- end }}
 
                 ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/jwt_authn/v3/config.proto#envoy-v3-api-msg-extensions-filters-http-jwt-authn-v3-remotejwks
                 remote_jwks:
                   http_uri:
-                    uri: "http://dex.{{ .Values.deployKF.auth.namespace }}.svc.{{ .Values.deployKF.clusterDomain }}:5556/dex/keys"
-                    cluster: "outbound|5556||dex.{{ .Values.deployKF.auth.namespace }}.svc.{{ .Values.deployKF.clusterDomain }}"
+                    uri: "http://dex.{{ $.Values.deployKF.auth.namespace }}.svc.{{ $.Values.deployKF.clusterDomain }}:5556/dex/keys"
+                    cluster: "outbound|5556||dex.{{ $.Values.deployKF.auth.namespace }}.svc.{{ $.Values.deployKF.clusterDomain }}"
                     timeout: 5s
                   cache_duration: 300s
 
@@ -237,28 +246,28 @@ spec:
                 provider_and_audiences:
                   provider_name: deploykf_dex
                   audiences:
-                    - {{ .Values.deployKF.auth.dex.clients.oauth2Proxy.clientId | quote }}
-                    - {{ .Values.deployKF.auth.dex.clients.kubeflowPipelinesSDK.clientId | quote }}
+                    - {{ $.Values.deployKF.auth.dex.clients.oauth2Proxy.clientId | quote }}
+                    - {{ $.Values.deployKF.auth.dex.clients.kubeflowPipelinesSDK.clientId | quote }}
 
               ## used by all other deployKF routes
               oauth2_proxy:
                 provider_and_audiences:
                   provider_name: deploykf_dex
                   audiences:
-                    - {{ .Values.deployKF.auth.dex.clients.oauth2Proxy.clientId | quote }}
+                    - {{ $.Values.deployKF.auth.dex.clients.oauth2Proxy.clientId | quote }}
+    {{- end }}
 
     ################################################################################
     ## FILTER 4 - Set USERID_HEADER from `x-auth-request-email`
     ################################################################################
+    {{- range $port_number := $listner_port_numbers }}
+    {{- "\n" }}
+    ## for port {{ $port_number }}
     - applyTo: HTTP_FILTER
       match:
         context: GATEWAY
         listener:
-          {{- if .Values.deployKF.gateway.tls.enabled }}
-          portNumber: {{ .Values.deployKF.gateway.ports.https | int }}
-          {{- else }}
-          portNumber: {{ .Values.deployKF.gateway.ports.http | int }}
-          {{- end }}
+          portNumber: {{ $port_number }}
           filterChain:
             filter:
               name: envoy.filters.network.http_connection_manager
@@ -300,7 +309,7 @@ spec:
                       )
                     end
 
-                    {{- if .Values.deployKF.gateway.emailToLowercase }}
+                    {{- if $.Values.deployKF.gateway.emailToLowercase }}
                     {{- "\n" }}
                     -- cast the value of 'x-auth-request-email' to lowercase
                     x_auth_request_email = string.lower(x_auth_request_email)
@@ -308,24 +317,24 @@ spec:
 
                     -- set Kubeflow USERID_HEADER from 'x-auth-request-email'
                     request_handle:headers():replace(
-                      "{{ .Values.deployKF.kubeflow.useridHeader }}",
+                      "{{ $.Values.deployKF.kubeflow.useridHeader }}",
                       x_auth_request_email
                     )
                   end
+    {{- end }}
 
     ################################################################################
     ## ROUTE - Enable auth on ALL deployKF Gateway routes
     ################################################################################
+    {{- range $port_number := $listner_port_numbers }}
+    {{- "\n" }}
+    ## for port {{ $port_number }}
     - applyTo: HTTP_ROUTE
       match:
         context: GATEWAY
         routeConfiguration:
-          {{- if .Values.deployKF.gateway.tls.enabled }}
-          portNumber: {{ .Values.deployKF.gateway.ports.https | int }}
-          {{- else }}
-          portNumber: {{ .Values.deployKF.gateway.ports.http | int }}
-          {{- end }}
-          gateway: "{{ .Release.Namespace }}/{{ .Values.deployKF.gateway.name }}"
+          portNumber: {{ $port_number }}
+          gateway: "{{ $.Release.Namespace }}/{{ $.Values.deployKF.gateway.name }}"
       patch:
         operation: MERGE
         value:
@@ -347,20 +356,20 @@ spec:
               ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/lua/v3/lua.proto#extensions-filters-http-lua-v3-luaperroute
               "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
               name: set_userid_header.lua
+    {{- end }}
 
     ################################################################################
     ## ROUTE - Use special JwtAuthn requirement for 'ml-pipeline-ui' route
     ################################################################################
+    {{- range $port_number := $listner_port_numbers }}
+    {{- "\n" }}
+    ## for port {{ $port_number }}
     - applyTo: HTTP_ROUTE
       match:
         context: GATEWAY
         routeConfiguration:
-          {{- if .Values.deployKF.gateway.tls.enabled }}
-          portNumber: {{ .Values.deployKF.gateway.ports.https | int }}
-          {{- else }}
-          portNumber: {{ .Values.deployKF.gateway.ports.http | int }}
-          {{- end }}
-          gateway: "{{ .Release.Namespace }}/{{ .Values.deployKF.gateway.name }}"
+          portNumber: {{ $port_number }}
+          gateway: "{{ $.Release.Namespace }}/{{ $.Values.deployKF.gateway.name }}"
           vhost:
             route:
               ## HTTP route names are specified in VirtualServices
@@ -374,21 +383,21 @@ spec:
               ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/jwt_authn/v3/config.proto#extensions-filters-http-jwt-authn-v3-perrouteconfig
               "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
               requirement_name: kubeflow_pipelines_api
+    {{- end }}
 
     {{- range $route_name := $disable_auth_routes }}
     {{- "\n" }}
     ################################################################################
     ## ROUTE - Disable auth for '{{ $route_name }}' route
     ################################################################################
+    {{- range $port_number := $listner_port_numbers }}
+    {{- "\n" }}
+    ## for port {{ $port_number }}
     - applyTo: HTTP_ROUTE
       match:
         context: GATEWAY
         routeConfiguration:
-          {{- if $.Values.deployKF.gateway.tls.enabled }}
-          portNumber: {{ $.Values.deployKF.gateway.ports.https | int }}
-          {{- else }}
-          portNumber: {{ $.Values.deployKF.gateway.ports.http | int }}
-          {{- end }}
+          portNumber: {{ $port_number }}
           gateway: "{{ $.Release.Namespace }}/{{ $.Values.deployKF.gateway.name }}"
           vhost:
             route:
@@ -421,4 +430,5 @@ spec:
               ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/lua/v3/lua.proto#extensions-filters-http-lua-v3-luaperroute
               "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
               disabled: true
+    {{- end }}
     {{- end }}

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/EnvoyFilter-kubeflow-pipelines.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/EnvoyFilter-kubeflow-pipelines.yaml
@@ -8,6 +8,14 @@
 ## NOTE: Kubeflow Pipelines will sometimes use an artifact which was cached by another namespace.
 ## NOTE: the user might still not have access after the redirect if they are not a member of the correct namespace.
 ################
+{{- /* the listener port-numbers to apply these patches to */ -}}
+{{- /* NOTE: Istio does NOT allow `match.routeConfiguration.gateway` to be used on HTTP routes (https://github.com/istio/istio/issues/46459),
+       so if HTTP routes are needed (when `deploykf_core.deploykf_istio_gateway.gateway.tls.redirect` is false),
+       they are implemented by internally proxying them to the HTTPS routes (see `VirtualService/https-redirect`) */ -}}
+{{- $listner_port_numbers := list }}
+{{- if .Values.deployKF.gateway.tls.enabled }}
+  {{- $listner_port_numbers = .Values.deployKF.gateway.ports.https | int | append $listner_port_numbers }}
+{{- end }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -27,15 +35,14 @@ spec:
     ################################################################################
     ## FILTER - Define the Lua filter
     ################################################################################
+    {{- range $port_number := $listner_port_numbers }}
+    {{- "\n" }}
+    ## for port {{ $port_number }}
     - applyTo: HTTP_FILTER
       match:
         context: GATEWAY
         listener:
-          {{- if .Values.deployKF.gateway.tls.enabled }}
-          portNumber: {{ .Values.deployKF.gateway.ports.https | int }}
-          {{- else }}
-          portNumber: {{ .Values.deployKF.gateway.ports.http | int }}
-          {{- end }}
+          portNumber: {{ $port_number }}
           filterChain:
             filter:
               name: envoy.filters.network.http_connection_manager
@@ -136,20 +143,20 @@ spec:
                           end
                       end
                   end
+    {{- end }}
 
     ################################################################################
     ## ROUTE - Enable lua filter for the 'ml-pipeline-ui-artifacts' route
     ################################################################################
+    {{- range $port_number := $listner_port_numbers }}
+    {{- "\n" }}
+    ## for port {{ $port_number }}
     - applyTo: HTTP_ROUTE
       match:
         context: GATEWAY
         routeConfiguration:
-          {{- if .Values.deployKF.gateway.tls.enabled }}
-          portNumber: {{ .Values.deployKF.gateway.ports.https | int }}
-          {{- else }}
-          portNumber: {{ .Values.deployKF.gateway.ports.http | int }}
-          {{- end }}
-          gateway: "{{ .Release.Namespace }}/{{ .Values.deployKF.gateway.name }}"
+          portNumber: {{ $port_number }}
+          gateway: "{{ $.Release.Namespace }}/{{ $.Values.deployKF.gateway.name }}"
           vhost:
             route:
               ## HTTP route names are specified in VirtualServices
@@ -163,5 +170,6 @@ spec:
               ## https://www.envoyproxy.io/docs/envoy/v1.23.1/api-v3/extensions/filters/http/lua/v3/lua.proto#extensions-filters-http-lua-v3-luaperroute
               "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
               name: kfp_redirect_artifact_namespaces.lua
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/Gateway-https-redirect.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/Gateway-https-redirect.yaml
@@ -12,6 +12,9 @@ spec:
   selector:
     {{- toYaml .Values.deployKF.gateway.selectorLabels | nindent 4 }}
   servers:
+    ################################################################################
+    ## HTTP
+    ################################################################################
     - hosts:
         ## this gateway only needs to select the `VirtualService/https-redirect`, even for the subdomains
         - "{{ .Release.Namespace }}/{{ .Values.deployKF.gateway.hostname }}"

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/Gateway.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/Gateway.yaml
@@ -1,3 +1,19 @@
+{{- define "deploykf-istio-gateway.gateway.server_hosts" }}
+## select VirtualServices in any namespace with the deployKF hostname
+- "*/{{ .Values.deployKF.gateway.hostname }}"
+
+{{- if .Values.deployKF.argoWorkflows.enabled }}
+## select VirtualService for Argo Workflows UI
+- "{{ .Values.deployKF.argoWorkflows.namespace }}/argo-server.{{ .Values.deployKF.gateway.hostname }}"
+{{- end }}
+
+{{- if .Values.deployKF.minio.enabled }}
+## select VirtualServices for Minio API and Console
+- "{{ .Values.deployKF.minio.namespace }}/minio-api.{{ .Values.deployKF.gateway.hostname }}"
+- "{{ .Values.deployKF.minio.namespace }}/minio-console.{{ .Values.deployKF.gateway.hostname }}"
+{{- end }}
+{{- end }}
+
 apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
@@ -11,25 +27,18 @@ spec:
   selector:
     {{- toYaml .Values.deployKF.gateway.selectorLabels | nindent 4 }}
   servers:
+    {{- if .Values.deployKF.gateway.tls.enabled }}
+    ################################################################################
+    ## HTTPS
+    ################################################################################
     - hosts:
-      {{- if and .Values.deployKF.gateway.tls.enabled (not .Values.deployKF.gateway.tls.matchSNI) }}
+        {{- if .Values.deployKF.gateway.tls.matchSNI }}
+        {{- include "deploykf-istio-gateway.gateway.server_hosts" . | indent 8 }}
+        {{- else }}
         ## NOTE: hosts is set to "*" because most external load balancers do not forward the SNI after TLS termination
         ##       https://istio.io/v1.19/docs/ops/common-problems/network-issues/#configuring-sni-routing-when-not-sending-sni
         - "*"
-      {{- else }}
-        ## select VirtualServices in any namespace with the deployKF hostname
-        - "*/{{ .Values.deployKF.gateway.hostname }}"
-        {{- if .Values.deployKF.argoWorkflows.enabled }}
-        ## select VirtualService for Argo Workflows UI
-        - "{{ .Values.deployKF.argoWorkflows.namespace }}/argo-server.{{ .Values.deployKF.gateway.hostname }}"
         {{- end }}
-        {{- if .Values.deployKF.minio.enabled }}
-        ## select VirtualServices for Minio API and Console
-        - "{{ .Values.deployKF.minio.namespace }}/minio-api.{{ .Values.deployKF.gateway.hostname }}"
-        - "{{ .Values.deployKF.minio.namespace }}/minio-console.{{ .Values.deployKF.gateway.hostname }}"
-        {{- end }}
-      {{- end }}
-      {{- if .Values.deployKF.gateway.tls.enabled }}
       port:
         name: https
         number: {{ .Values.deployKF.gateway.ports.https | int }}
@@ -37,9 +46,4 @@ spec:
       tls:
         mode: SIMPLE
         credentialName: deploykf-istio-gateway-cert
-      {{- else }}
-      port:
-        name: http
-        number: {{ .Values.deployKF.gateway.ports.http | int }}
-        protocol: HTTP
-      {{- end }}
+    {{- end }}

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/VirtualService-https-redirect.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/VirtualService-https-redirect.yaml
@@ -1,8 +1,13 @@
 {{- if .Values.deployKF.gateway.tls.enabled }}
 ################
-## This VirtualService is here to redirect all HTTP traffic to HTTPS.
-## We can't use the `Gateway/spec.servers[*].tls.httpsRedirect`, as it blindly swaps the schema from `http://` to `https://`
-## without changing the port, and we allow users to specify non-standard HTTPS ports.
+## If `deployKF.gateway.tls.redirect` is true:
+##  - This VirtualService is here to redirect all HTTP traffic to HTTPS.
+##  - NOTE: we can't use the `Gateway/spec.servers[*].tls.httpsRedirect` as it blindly swaps the schema from
+##    `http://` to `https://` without changing the port (and we allow users to specify non-standard HTTPS ports).
+##
+## If `deployKF.gateway.tls.redirect` is false:
+##  - This VirtualService proxies all HTTP requests back to the Gateway as HTTPS requests.
+##    See `DestinationRule/https-redirect` and `EnvoyFilter/deploykf-istio-gateway--ext-authz` for more context.
 ################
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
@@ -20,13 +25,21 @@ spec:
     - {{ .Values.deployKF.gateway.hostname | quote }}
     - "*.{{ .Values.deployKF.gateway.hostname }}"
   http:
-    - name: https-redirect-route
-      match:
+    - match:
         - scheme:
             exact: http
           port: {{ .Values.deployKF.gateway.ports.http | int }}
+      {{- $public_https_port := .Values.deployKF.gateway.servicePorts.https | default .Values.deployKF.gateway.ports.https }}
+      {{- if .Values.deployKF.gateway.tls.redirect }}
       redirect:
         scheme: https
-        port: {{ .Values.deployKF.gateway.servicePorts.https | default .Values.deployKF.gateway.ports.https | int }}
+        port: {{ $public_https_port }}
         redirectCode: 307
+      {{- else }}
+      route:
+        - destination:
+            host: {{ .Values.deployKF.gateway.hostname | quote }}
+            port:
+              number: {{ $public_https_port }}
+      {{- end }}
 {{- end }}

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/values.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/values.yaml
@@ -65,7 +65,9 @@ deployKF:
       https: {{< .Values.deploykf_core.deploykf_istio_gateway.gatewayService.ports.https | default "~" >}}
     tls:
       enabled: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.enabled | conv.ToBool >}}
+      clientsUseHttps: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.clientsUseHttps | conv.ToBool >}}
       matchSNI: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.matchSNI | conv.ToBool >}}
+      redirect: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.redirect | conv.ToBool >}}
     enableProxyProtocol: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.enableProxyProtocol >}}
     xffNumTrustedHops: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.xffNumTrustedHops >}}
     emailToLowercase: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.emailToLowercase | conv.ToBool >}}

--- a/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Deployment.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Deployment.yaml
@@ -87,7 +87,7 @@ spec:
 
             ## minio - console
             - name: MINIO_BROWSER_REDIRECT_URL
-              {{- if .Values.deployKF.gateway.tls.enabled }}
+              {{- if .Values.deployKF.gateway.tls.clientsUseHttps }}
               value: "https://minio-console.{{ .Values.deployKF_helpers.deploykf_gateway.https_endpoint }}"
               {{- else }}
               value: "http://minio-console.{{ .Values.deployKF_helpers.deploykf_gateway.http_endpoint }}"
@@ -100,7 +100,7 @@ spec:
             - name: MINIO_IDENTITY_OPENID_DISPLAY_NAME
               value: {{ .Values.minio.identity.openid.displayName | quote }}
             - name: MINIO_IDENTITY_OPENID_CONFIG_URL
-              {{- if .Values.deployKF.gateway.tls.enabled }}
+              {{- if .Values.deployKF.gateway.tls.clientsUseHttps }}
               value: "https://{{ .Values.deployKF_helpers.deploykf_gateway.https_endpoint }}/dex/.well-known/openid-configuration"
               {{- else }}
               value: "http://{{ .Values.deployKF_helpers.deploykf_gateway.http_endpoint }}/dex/.well-known/openid-configuration"
@@ -120,7 +120,7 @@ spec:
             - name: MINIO_IDENTITY_OPENID_CLAIM_NAME
               value: {{ .Values.minio.identity.openid.policyClaim | quote }}
             - name: MINIO_IDENTITY_OPENID_REDIRECT_URI
-              {{- if .Values.deployKF.gateway.tls.enabled }}
+              {{- if .Values.deployKF.gateway.tls.clientsUseHttps }}
               value: "https://minio-console.{{ .Values.deployKF_helpers.deploykf_gateway.https_endpoint }}/oauth_callback"
               {{- else }}
               value: "http://minio-console.{{ .Values.deployKF_helpers.deploykf_gateway.http_endpoint }}/oauth_callback"

--- a/generator/templates/manifests/deploykf-opt/deploykf-minio/values.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-minio/values.yaml
@@ -37,6 +37,7 @@ deployKF:
     hostname: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.hostname | quote >}}
     tls:
       enabled: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.enabled | conv.ToBool >}}
+      clientsUseHttps: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.clientsUseHttps | conv.ToBool >}}
 
 
 ########################################

--- a/generator/templates/manifests/kubeflow-dependencies/kubeflow-argo-workflows/templates/ConfigMap-argo-config.yaml
+++ b/generator/templates/manifests/kubeflow-dependencies/kubeflow-argo-workflows/templates/ConfigMap-argo-config.yaml
@@ -41,7 +41,7 @@ data:
 
   sso: |
     ## the issuer of the OIDC provider
-    {{- if .Values.deployKF.gateway.tls.enabled }}
+    {{- if .Values.deployKF.gateway.tls.clientsUseHttps }}
     issuer: "https://{{ .Values.deployKF_helpers.deploykf_gateway.https_endpoint }}/dex"
     {{- else }}
     issuer: "http://{{ .Values.deployKF_helpers.deploykf_gateway.http_endpoint }}/dex"
@@ -74,7 +74,7 @@ data:
       {{- end }}
 
     ## the OIDC redirect URL
-    {{- if .Values.deployKF.gateway.tls.enabled }}
+    {{- if .Values.deployKF.gateway.tls.clientsUseHttps }}
     redirectUrl: "https://argo-server.{{ .Values.deployKF_helpers.deploykf_gateway.https_endpoint }}/oauth2/callback"
     {{- else }}
     redirectUrl: "http://argo-server.{{ .Values.deployKF_helpers.deploykf_gateway.http_endpoint }}/oauth2/callback"

--- a/generator/templates/manifests/kubeflow-dependencies/kubeflow-argo-workflows/values.yaml
+++ b/generator/templates/manifests/kubeflow-dependencies/kubeflow-argo-workflows/values.yaml
@@ -48,6 +48,7 @@ deployKF:
     hostname: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.hostname | quote >}}
     tls:
       enabled: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.enabled | conv.ToBool >}}
+      clientsUseHttps: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.clientsUseHttps | conv.ToBool >}}
 
   pipelines:
     bucket:


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR makes it possible to disable the HTTP->HTTPS redirect on the gateway with a new `deploykf_core.deploykf_istio_gateway.gateway.tls.redirect` value (default: `true`), and thus allows clients to talk over HTTP to the gateway.

We also introduced the `deploykf_core.deploykf_istio_gateway.gateway.tls.clientsUseHttps` value (default: `true`) which is how deployKF decides what protocol of links and cookies presented to client browsers.

__WARNING:__ There is only ONE case where clients should talk to the gateway over HTTP. When the "client" is a proxy/load-balancer that is providing the actual "end users" its own TLS termination, but is unable to communicate with the backend over HTTPS.

---

__Advanced Stuff:__

We implement authentication using EnvoyFilters, we insert a bunch of HTTP_FILTER to the listener chain. These filters are set to do nothing by default, and are enabled per-route by selecting from VirtualServices which select our `deploykf-gateway` Gateway.

The problem is that we are unable to select routes by Gateway for HTTP listeners (https://github.com/istio/istio/issues/46459), which means that authentication would not be enabled properly over HTTP.

We resolved this issue by simply making the HTTP listener an internal proxy to our HTTPS routes, which means that all HTTP requests end up on the HTTPS routes (which have authentication correctly set up), at the expense of one additional proxy hop.

For this reason, we no longer allow users to set `deploykf_core.deploykf_istio_gateway.gateway.tls.enabled` to `false`. However, we have left the value in the templates, so that if in the future, it becomes possible to avoid this work-around, we can more easily return to allowing users to disable the HTTPS listener on the gateway.