### PR TITLE
improve: use `__Secure-` cookie prefix and remove domains config

### DIFF
--- a/generator/templates/manifests/deploykf-core/deploykf-auth/templates/oauth2-proxy/Secret-config.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-auth/templates/oauth2-proxy/Secret-config.yaml
@@ -102,11 +102,14 @@ oidc_extra_audiences = [
 ################
 ## cookie
 ################
-cookie_name = {{ .Values.oauth2Proxy.cookie.name | quote }}
+{{- /* we prepend "__Secure-" to the cookie name for secure connections */ -}}
+{{- $cookie_name := .Values.oauth2Proxy.cookie.name }}
+{{- if .Values.deployKF.gateway.tls.clientsUseHttps }}
+{{- $cookie_name = print "__Secure-" ($cookie_name | trimPrefix "__Secure-") }}
+{{- end }}
+cookie_name = {{ $cookie_name | quote }}
 cookie_path = "/"
-cookie_domains = [
-  {{ .Values.deployKF.gateway.hostname | quote }}
-]
+cookie_domains = []
 cookie_expire = {{ .Values.oauth2Proxy.cookie.expire | quote }}
 cookie_refresh = {{ .Values.oauth2Proxy.cookie.refresh | quote }}
 {{- if .Values.deployKF.gateway.tls.clientsUseHttps }}


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR prepends `__Secure-` to our token cookie name when `deploykf_core.deploykf_istio_gateway.gateway.tls.clientsUseHttps` is true (indicating that users are connecting to deplopyKF over HTTPS), as browsers require HTTPS for the `Secure` attribute to be set, which itself is required to use the `__Secure-` prefix.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#__host-

We also set `cookie_domains` to an empty list in our oauth2-proxy configs, as previously oauth2-proxy was spamming `[WARNING] ...` logs because it could not match the cookie domain to requests (when using non-standard ports). This change should have no effect, as deployKF currently always uses the same `deploykf_core.deploykf_istio_gateway.gateway.hostname` for all services so there is no reason to "force" a specific top-level one.