### PR TITLE
fix: annotate cloned imagePullSecrets to be ignored by ArgoCD

### DIFF
--- a/generator/templates/manifests/deploykf-dependencies/kyverno/templates/ClusterPolicy-image-pull-secrets.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/kyverno/templates/ClusterPolicy-image-pull-secrets.yaml
@@ -60,7 +60,7 @@ spec:
       exclude:
         any:
           - resources:
-              names: {{ $exclude_namespaces | toJson }}
+              namespaces: {{ $exclude_namespaces | toJson }}
       mutate:
         patchStrategicMerge:
           metadata:

--- a/generator/templates/manifests/deploykf-dependencies/kyverno/templates/ClusterPolicy-image-pull-secrets.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/kyverno/templates/ClusterPolicy-image-pull-secrets.yaml
@@ -15,6 +15,7 @@ metadata:
 spec:
   generateExisting: true
   rules:
+    {{- $this_policy_name := "clone-image-pull-secrets" }}
     {{- range $index, $credentials := .Values.deployKF.kyverno.clusterPolicies.imagePullSecrets.registryCredentials }}
     {{- $source_secret__name := $credentials.existingSecret }}
     {{- $source_secret__namespace := $credentials.existingSecretNamespace | default $.Release.Namespace }}
@@ -40,6 +41,32 @@ spec:
         clone:
           namespace: {{ $source_secret__namespace | quote }}
           name: {{ $source_secret__name | quote }}
+
+    ## annotate the ~cloned~ secret so that ArgoCD ignores it
+    - name: {{ printf "annotate-cloned-secret-%d" $index | quote }}
+      match:
+        any:
+          - resources:
+              kinds:
+                - Secret
+              names:
+                - {{ $target_secret__name | quote }}
+              operations:
+                - CREATE
+                - UPDATE
+              selector:
+                matchLabels:
+                  generate.kyverno.io/policy-name: {{ $this_policy_name | quote }}
+      exclude:
+        any:
+          - resources:
+              names: {{ $exclude_namespaces | toJson }}
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            annotations:
+              argocd.argoproj.io/compare-options: IgnoreExtraneous
+              argocd.argoproj.io/sync-options: Prune=false
     {{- end }}
 
     ## add all the ~cloned~ secrets to the list of imagePullSecrets for all pods


### PR DESCRIPTION
This PR makes it so that secrets cloned by the `deploykf_dependencies.kyverno.clusterPolicies.imagePullSecrets` policy are annotated with `argocd.argoproj.io/compare-options: IgnoreExtraneous` and `argocd.argoproj.io/sync-options: Prune=false` to prevent ArgoCD pruning them or showing source secret's app as our of sync (if it comes from one).