### PR TITLE
fix: support kyverno chart changes (but keep kyverno version)

### DIFF
--- a/generator/templates/manifests/deploykf-core/deploykf-auth/templates/ClusterPolicy--restart-on-secret-updates.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-auth/templates/ClusterPolicy--restart-on-secret-updates.yaml
@@ -55,7 +55,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  mutateExistingOnPolicyUpdate: false
   rules:
     - name: trigger-deployment-restarts
       match:
@@ -73,7 +72,7 @@ spec:
         targets:
           - apiVersion: apps/v1
             kind: Deployment
-            namespace: {{ `"{{ request.namespace }}"` }}
+            namespace: {{ `"{{ request.object.metadata.namespace }}"` }}
         patchStrategicMerge:
           metadata:
             labels:

--- a/generator/templates/manifests/deploykf-dependencies/kyverno/values.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/kyverno/values.yaml
@@ -160,6 +160,7 @@ kyverno:
           {{<- range $extra_resource := $extra_resources >}}
           - apiGroups: {{< $extra_resource.apiGroups | toJSON >}}
             resources: {{< $extra_resource.resources | toJSON >}}
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
           {{<- end >}}
 
   ## Reports controller configuration

--- a/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/ClusterPolicy--restart-on-secret-updates.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/ClusterPolicy--restart-on-secret-updates.yaml
@@ -27,7 +27,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  mutateExistingOnPolicyUpdate: false
   rules:
     - name: trigger-deployment-restarts
       match:
@@ -45,7 +44,7 @@ spec:
         targets:
           - apiVersion: apps/v1
             kind: Deployment
-            namespace: {{ `"{{ request.namespace }}"` }}
+            namespace: {{ `"{{ request.object.metadata.namespace }}"` }}
         patchStrategicMerge:
           metadata:
             labels:

--- a/generator/templates/manifests/deploykf-opt/deploykf-mysql/templates/ClusterPolicy--restart-on-secret-updates.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-mysql/templates/ClusterPolicy--restart-on-secret-updates.yaml
@@ -38,7 +38,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  mutateExistingOnPolicyUpdate: false
   rules:
     - name: trigger-statefulset-restarts
       match:
@@ -56,7 +55,7 @@ spec:
         targets:
           - apiVersion: apps/v1
             kind: StatefulSet
-            namespace: {{ `"{{ request.namespace }}"` }}
+            namespace: {{ `"{{ request.object.metadata.namespace }}"` }}
         patchStrategicMerge:
           metadata:
             labels:

--- a/generator/templates/manifests/kubeflow-tools/katib/resources/restart-on-mysql-secret-update-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/katib/resources/restart-on-mysql-secret-update-clusterpolicy.yaml
@@ -4,7 +4,6 @@ kind: ClusterPolicy
 metadata:
   name: kubeflow-katib--restart-on-secret-update--mysql
 spec:
-  mutateExistingOnPolicyUpdate: false
   rules:
     - name: trigger-deployment-restarts
       match:
@@ -23,7 +22,7 @@ spec:
         targets:
           - apiVersion: apps/v1
             kind: Deployment
-            namespace: "{{ request.namespace }}"
+            namespace: "{{ request.object.metadata.namespace }}"
         patchStrategicMerge:
           spec:
             template:

--- a/generator/templates/manifests/kubeflow-tools/pipelines/resources/restart-on-mysql-secret-update-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/resources/restart-on-mysql-secret-update-clusterpolicy.yaml
@@ -4,7 +4,6 @@ kind: ClusterPolicy
 metadata:
   name: kubeflow-pipelines--restart-on-secret-update--mysql
 spec:
-  mutateExistingOnPolicyUpdate: false
   rules:
     - name: trigger-deployment-restarts
       match:
@@ -23,7 +22,7 @@ spec:
         targets:
           - apiVersion: apps/v1
             kind: Deployment
-            namespace: "{{ request.namespace }}"
+            namespace: "{{ request.object.metadata.namespace }}"
         patchStrategicMerge:
           spec:
             template:

--- a/generator/templates/manifests/kubeflow-tools/pipelines/resources/restart-on-pipeline-configmap-update-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/resources/restart-on-pipeline-configmap-update-clusterpolicy.yaml
@@ -3,7 +3,6 @@ kind: ClusterPolicy
 metadata:
   name: kubeflow-pipelines--restart-on-pipeline-configmap-update
 spec:
-  mutateExistingOnPolicyUpdate: false
   rules:
     - name: trigger-deployment-restarts
       match:
@@ -22,7 +21,7 @@ spec:
         targets:
           - apiVersion: apps/v1
             kind: Deployment
-            namespace: "{{ request.namespace }}"
+            namespace: "{{ request.object.metadata.namespace }}"
         patchStrategicMerge:
           spec:
             template:


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR addresses an incompatible change introduced in newer versions of the Kyverno chart, mainly that `kyverno.cleanupController.rbac.clusterRole.extraResources[0].verbs` now needs to be set.

It also cleans up two case where we set `mutateExistingOnPolicyUpdate: false` despite that being the default, and replaced instances of `{{ request.namespace }}` with `{{ request.object.metadata.namespace }}` because these seem to be problematic in Kyverno 1.11.

However, the Kyverno version remains as `1.10.0`, and we have left the chart version as `3.0.1`

---

__WARNING:__ We still can NOT update to any version of Kyverno from `1.10.1` to `1.11.4`, as all have problems that make them incompatible with deployKF:

- https://github.com/kyverno/kyverno/issues/9134
- https://github.com/kyverno/kyverno/issues/9571
- https://github.com/kyverno/kyverno/issues/9560
    - ___NOTE:__ While this was not "broken" it was a change in behavior from what we relied on. So we may need to use an alternative secret-cloning tool to move secrets across namespaces._
- https://github.com/kyverno/kyverno/issues/9633