### PR TITLE
improve: increase kyverno resource limits and add values

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -349,21 +349,45 @@ deploykf_dependencies:
     ##
     admissionController:
       replicas: 3
+      resources:
+        limits:
+          memory: 384Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
 
     ## kyverno background controller configs
     ##
     backgroundController:
       replicas: 1
+      resources:
+        limits:
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
 
     ## kyverno cleanup controller configs
     ##
     cleanupController:
       replicas: 1
+      resources:
+        limits:
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
 
     ## kyverno reports controller configs
     ##
     reportsController:
       replicas: 1
+      resources:
+        limits:
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
 
     ## kyverno policy configs
     ##

--- a/generator/templates/manifests/deploykf-dependencies/kyverno/values.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/kyverno/values.yaml
@@ -112,6 +112,7 @@ kyverno:
         {{<- end >}}
         pullPolicy: {{< .Values.deploykf_dependencies.kyverno.images.kyvernoInit.pullPolicy | quote >}}
     container:
+      resources: {{< .Values.deploykf_dependencies.kyverno.admissionController.resources | toJSON >}}
       image:
         registry: ""
         repository: {{< .Values.deploykf_dependencies.kyverno.images.kyverno.repository | quote >}}
@@ -127,6 +128,7 @@ kyverno:
   backgroundController:
     enabled: true
     replicas: {{< .Values.deploykf_dependencies.kyverno.backgroundController.replicas | conv.ToInt >}}
+    resources: {{< .Values.deploykf_dependencies.kyverno.backgroundController.resources | toJSON >}}
     image:
       registry: ""
       repository: {{< .Values.deploykf_dependencies.kyverno.images.kyvernoBackgroundController.repository | quote >}}
@@ -147,6 +149,7 @@ kyverno:
   cleanupController:
     enabled: true
     replicas: {{< .Values.deploykf_dependencies.kyverno.cleanupController.replicas | conv.ToInt >}}
+    resources: {{< .Values.deploykf_dependencies.kyverno.cleanupController.resources | toJSON >}}
     image:
       registry: ""
       repository: {{< .Values.deploykf_dependencies.kyverno.images.kyvernoCleanupController.repository | quote >}}
@@ -167,6 +170,7 @@ kyverno:
   reportsController:
     enabled: true
     replicas: {{< .Values.deploykf_dependencies.kyverno.reportsController.replicas | conv.ToInt >}}
+    resources: {{< .Values.deploykf_dependencies.kyverno.reportsController.resources | toJSON >}}
     image:
       registry: ""
       repository: {{< .Values.deploykf_dependencies.kyverno.images.kyvernoReportsController.repository | quote >}}


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR increases the default memory limit for the Kyverno background controller to `512Mi` and adds values to allow users to customize it further.

This was necessary because our version of Kyverno (1.10.0, which we must use due to issues in newer versions, see https://github.com/deployKF/deployKF/pull/92), uses more memory when running deployKF than is allowed by its default configs.

The following values have been added:

- `deploykf_dependencies.kyverno.admissionController.resources`
- `deploykf_dependencies.kyverno.backgroundController.resources`
- `deploykf_dependencies.kyverno.cleanupController.resources`
- `deploykf_dependencies.kyverno.reportsController.resources`