### PR TITLE
improve: use CRD-level "replace" for kyverno ArgoCD app

### DIFF
--- a/generator/templates/argocd/applications/deploykf-dependencies/kyverno.yaml
+++ b/generator/templates/argocd/applications/deploykf-dependencies/kyverno.yaml
@@ -37,8 +37,3 @@ spec:
     server: {{< .Values.argocd.destination.server | quote >}}
     {{<- end >}}
     namespace: {{< .Values.deploykf_dependencies.kyverno.namespace | quote >}}
-  syncPolicy:
-    syncOptions:
-      ## kyverno will fail to sync if not using one of `Replace` or `ServerSideApply`
-      ## https://kyverno.io/docs/installation/platform-notes/#notes-for-argocd-users
-      - ServerSideApply=true

--- a/generator/templates/manifests/deploykf-dependencies/kyverno/values.yaml
+++ b/generator/templates/manifests/deploykf-dependencies/kyverno/values.yaml
@@ -49,7 +49,16 @@ deployKF:
 kyverno:
   fullnameOverride: kyverno
 
+  ## Kyverno CRDs
+  crds:
+    install: true
+    annotations:
+      ## kyverno will fail to sync if not using one of `Replace` or `ServerSideApply`
+      ## https://kyverno.io/docs/installation/platform-notes/#notes-for-argocd-users
+      argocd.argoproj.io/sync-options: "Replace=true"
+
   {{<- if .Values.kubernetes.azure.admissionsEnforcerFix >}}
+  {{<- "\n" >}}
   ## Kyverno configurations
   config:
     ## azure aks admissions enforcer fix


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR makes it so that we no longer have to enable ArgoCD's ServerSideApply feature at the application level for Kyverno.

We can instead work around the same issue ([where annotation limits are exceeded because Kyverno's CRDs are so big](https://kyverno.io/docs/installation/platform-notes/#notes-for-argocd-users)), by simply annotating the CRD resources with `argocd.argoproj.io/sync-options: "Replace=true"`.