### PR TITLE
fix: add background filter to restart trigger policies

### DIFF
--- a/generator/templates/manifests/deploykf-core/deploykf-auth/templates/ClusterPolicy--restart-on-secret-updates.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-auth/templates/ClusterPolicy--restart-on-secret-updates.yaml
@@ -68,6 +68,13 @@ spec:
               operations:
                 - CREATE
                 - UPDATE
+      preconditions:
+        all:
+          - key: {{ `"{{ request.operation || 'BACKGROUND' }}"` }}
+            operator: AnyIn
+            value:
+              - CREATE
+              - UPDATE
       mutate:
         targets:
           - apiVersion: apps/v1

--- a/generator/templates/manifests/deploykf-core/deploykf-auth/templates/dex/ClusterPolicy-clone-argo-server-openid-secret.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-auth/templates/dex/ClusterPolicy-clone-argo-server-openid-secret.yaml
@@ -78,6 +78,13 @@ spec:
               operations:
                 - CREATE
                 - UPDATE
+      preconditions:
+        all:
+          - key: {{ `"{{ request.operation || 'BACKGROUND' }}"` }}
+            operator: AnyIn
+            value:
+              - CREATE
+              - UPDATE
       mutate:
         targets:
           - apiVersion: apps/v1

--- a/generator/templates/manifests/deploykf-core/deploykf-auth/templates/dex/ClusterPolicy-clone-minio-openid-secret.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-auth/templates/dex/ClusterPolicy-clone-minio-openid-secret.yaml
@@ -78,6 +78,13 @@ spec:
               operations:
                 - CREATE
                 - UPDATE
+      preconditions:
+        all:
+          - key: {{ `"{{ request.operation || 'BACKGROUND' }}"` }}
+            operator: AnyIn
+            value:
+              - CREATE
+              - UPDATE
       mutate:
         targets:
           - apiVersion: apps/v1

--- a/generator/templates/manifests/deploykf-core/deploykf-profiles-generator/templates/profile-tools--kubeflow-pipelines.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-profiles-generator/templates/profile-tools--kubeflow-pipelines.yaml
@@ -171,6 +171,13 @@ spec:
               operations:
                 - CREATE
                 - UPDATE
+      preconditions:
+        all:
+          - key: {{ `"{{ request.operation || 'BACKGROUND' }}"` }}
+            operator: AnyIn
+            value:
+              - CREATE
+              - UPDATE
       mutate:
         targets:
           - apiVersion: apps/v1

--- a/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/ClusterPolicy--restart-on-secret-updates.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/ClusterPolicy--restart-on-secret-updates.yaml
@@ -40,6 +40,13 @@ spec:
               operations:
                 - CREATE
                 - UPDATE
+      preconditions:
+        all:
+          - key: {{ `"{{ request.operation || 'BACKGROUND' }}"` }}
+            operator: AnyIn
+            value:
+              - CREATE
+              - UPDATE
       mutate:
         targets:
           - apiVersion: apps/v1

--- a/generator/templates/manifests/deploykf-opt/deploykf-mysql/templates/ClusterPolicy--restart-on-secret-updates.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-mysql/templates/ClusterPolicy--restart-on-secret-updates.yaml
@@ -51,6 +51,13 @@ spec:
               operations:
                 - CREATE
                 - UPDATE
+      preconditions:
+        all:
+          - key: {{ `"{{ request.operation || 'BACKGROUND' }}"` }}
+            operator: AnyIn
+            value:
+              - CREATE
+              - UPDATE
       mutate:
         targets:
           - apiVersion: apps/v1

--- a/generator/templates/manifests/kubeflow-dependencies/kubeflow-argo-workflows/templates/ClusterPolicy-clone-bucket-secret.yaml
+++ b/generator/templates/manifests/kubeflow-dependencies/kubeflow-argo-workflows/templates/ClusterPolicy-clone-bucket-secret.yaml
@@ -80,6 +80,13 @@ spec:
               operations:
                 - CREATE
                 - UPDATE
+      preconditions:
+        all:
+          - key: {{ `"{{ request.operation || 'BACKGROUND' }}"` }}
+            operator: AnyIn
+            value:
+              - CREATE
+              - UPDATE
       mutate:
         targets:
           - apiVersion: apps/v1

--- a/generator/templates/manifests/kubeflow-tools/katib/resources/clone-mysql-secret-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/katib/resources/clone-mysql-secret-clusterpolicy.yaml
@@ -74,6 +74,13 @@ spec:
               operations:
                 - CREATE
                 - UPDATE
+      preconditions:
+        all:
+          - key: "{{ request.operation || 'BACKGROUND' }}"
+            operator: AnyIn
+            value: 
+              - CREATE
+              - UPDATE
       mutate:
         targets:
           - apiVersion: apps/v1

--- a/generator/templates/manifests/kubeflow-tools/katib/resources/restart-on-mysql-secret-update-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/katib/resources/restart-on-mysql-secret-update-clusterpolicy.yaml
@@ -18,6 +18,13 @@ spec:
               operations:
                 - CREATE
                 - UPDATE
+      preconditions:
+        all:
+          - key: "{{ request.operation || 'BACKGROUND' }}"
+            operator: AnyIn
+            value: 
+              - CREATE
+              - UPDATE
       mutate:
         targets:
           - apiVersion: apps/v1

--- a/generator/templates/manifests/kubeflow-tools/pipelines/resources/clone-bucket-secret-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/resources/clone-bucket-secret-clusterpolicy.yaml
@@ -74,6 +74,13 @@ spec:
               operations:
                 - CREATE
                 - UPDATE
+      preconditions:
+        all:
+          - key: "{{ request.operation || 'BACKGROUND' }}"
+            operator: AnyIn
+            value: 
+              - CREATE
+              - UPDATE
       mutate:
         targets:
           - apiVersion: apps/v1

--- a/generator/templates/manifests/kubeflow-tools/pipelines/resources/clone-mysql-secret-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/resources/clone-mysql-secret-clusterpolicy.yaml
@@ -74,6 +74,13 @@ spec:
               operations:
                 - CREATE
                 - UPDATE
+      preconditions:
+        all:
+          - key: "{{ request.operation || 'BACKGROUND' }}"
+            operator: AnyIn
+            value: 
+              - CREATE
+              - UPDATE
       mutate:
         targets:
           - apiVersion: apps/v1

--- a/generator/templates/manifests/kubeflow-tools/pipelines/resources/restart-on-mysql-secret-update-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/resources/restart-on-mysql-secret-update-clusterpolicy.yaml
@@ -18,6 +18,13 @@ spec:
               operations:
                 - CREATE
                 - UPDATE
+      preconditions:
+        all:
+          - key: "{{ request.operation || 'BACKGROUND' }}"
+            operator: AnyIn
+            value: 
+              - CREATE
+              - UPDATE
       mutate:
         targets:
           - apiVersion: apps/v1

--- a/generator/templates/manifests/kubeflow-tools/pipelines/resources/restart-on-pipeline-configmap-update-clusterpolicy.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/resources/restart-on-pipeline-configmap-update-clusterpolicy.yaml
@@ -17,6 +17,13 @@ spec:
               operations:
                 - CREATE
                 - UPDATE
+      preconditions:
+        all:
+          - key: "{{ request.operation || 'BACKGROUND' }}"
+            operator: AnyIn
+            value: 
+              - CREATE
+              - UPDATE
       mutate:
         targets:
           - apiVersion: apps/v1


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR adds a precondition to filter out BACKGROUND events on our restart trigger policies.

This is needed because, in later versions of Kyverno, [each `BACKGROUND_SCAN_INTERVAL` the mutation will be applied](https://kyverno.io/docs/writing-policies/mutate/#mutate-existing-resources), which will cause our deployments to restart erroneously. 

Note, that this behavior ONLY applies to "mutate existing" rules (which define `targets`), so we don't need to update the other rules, like those that annotate the cloned secrets.