### PR TITLE
feat: istio gateway configurable secret name and certmanager usage

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -723,6 +723,9 @@ deploykf_core:
         ##
         enabled: true
 
+        ## the secret containing the gateway's TLS certificate and key
+        secretName: deploykf-istio-gateway-cert
+
         ## if browser clients use HTTPS when connecting to the gateway
         ##  - determines the protocol of links and cookies presented to client browsers,
         ##    should ~only~ be false if your end-users connect over HTTP, which is NOT recommended

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/Certificate.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/Certificate.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.deployKF.gateway.tls.enabled }}
+{{- if .Values.deployKF.certManager.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -9,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  secretName: deploykf-istio-gateway-cert
+  secretName: {{ .Values.deployKF.gateway.tls.secretName | default "deploykf-istio-gateway-cert" }}
   issuerRef:
     kind: ClusterIssuer
     name: {{ .Values.deployKF.certManager.clusterIssuer.issuerName | quote }}
@@ -17,4 +18,5 @@ spec:
   dnsNames:
     - "*.{{ .Values.deployKF.gateway.hostname }}"
     - {{ .Values.deployKF.gateway.hostname | quote }}
+{{- end }}
 {{- end }}

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/Gateway.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/Gateway.yaml
@@ -45,5 +45,5 @@ spec:
         protocol: HTTPS
       tls:
         mode: SIMPLE
-        credentialName: deploykf-istio-gateway-cert
+        credentialName: {{ .Values.deployKF.gateway.tls.secretName | default "deploykf-istio-gateway-cert" }}
     {{- end }}

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/values.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/values.yaml
@@ -33,6 +33,7 @@ deployKF:
       enabled: {{< .Values.kubeflow_tools.tensorboards.enabled | conv.ToBool >}}
 
   certManager:
+    enabled: {{< .Values.deploykf_dependencies.cert_manager.enabled | conv.ToBool >}}
     clusterIssuer:
       issuerName: {{< .Values.deploykf_dependencies.cert_manager.clusterIssuer.issuerName | quote >}}
 
@@ -65,6 +66,7 @@ deployKF:
       https: {{< .Values.deploykf_core.deploykf_istio_gateway.gatewayService.ports.https | default "~" >}}
     tls:
       enabled: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.enabled | conv.ToBool >}}
+      secretName: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.secretName | quote >}}
       clientsUseHttps: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.clientsUseHttps | conv.ToBool >}}
       matchSNI: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.matchSNI | conv.ToBool >}}
       redirect: {{< .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.redirect | conv.ToBool >}}


### PR DESCRIPTION
Added ability to configure certManager usage and tls secret name for istio gateway. If I missed something please let me know and I`ll fix it.