### PR TITLE
fix: prevent CSRF cookie accumulation on auth expiry

### DIFF
--- a/generator/templates/manifests/deploykf-core/deploykf-auth/templates/oauth2-proxy/Secret-config.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-auth/templates/oauth2-proxy/Secret-config.yaml
@@ -8,6 +8,21 @@ upstreams = [
   "static://200"
 ]
 
+## requests to paths matching these regex patterns will receive a 401 Unauthorized response
+## when not authenticated, instead of being redirected to the login page with a 302
+## (prevents background requests being redirected to the login page, and the accumulation of CSRF cookies)
+api_routes = [
+  ## Generic
+  ## NOTE: included because most background requests contain these paths
+  "/api/",
+  "/apis/",
+
+  ## Kubeflow Pipelines
+  ## NOTE: included because KFP UI makes MANY background requests to these paths but because they are
+  ##       not `application/json` requests, oauth2-proxy will redirect them to the login page
+  "^/ml_metadata",
+]
+
 ################
 ## proxy
 ################

--- a/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/EnvoyFilter-ext-authz.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-istio-gateway/templates/gateway/EnvoyFilter-ext-authz.yaml
@@ -144,8 +144,15 @@ spec:
                 ## NOTE: envoy automatically adds: `Host`, `Method`, `Path`, `Content-Length`, `Authorization`
                 allowed_headers:
                   patterns:
+                    ## oauth2-proxy uses the `accept` header to not redirect `application/json` requests
+                    - exact: accept
+                      ignore_case: true
+
+                    ## tokens are stored in cookies
                     - exact: cookie
                       ignore_case: true
+
+                    ## used by oauth2-proxy to know about the original request
                     - exact: x-forwarded-for
                       ignore_case: true
                     - exact: x-forwarded-host
@@ -159,6 +166,7 @@ spec:
                 ## NOTE: the client never sees these headers, only the downstream apps
                 allowed_upstream_headers:
                   patterns:
+                    ## oauth2-proxy will set/overwrite these headers for authenticated requests
                     - exact: authorization
                       ignore_case: true
                     - exact: x-auth-request-email
@@ -168,14 +176,18 @@ spec:
                 ## NOTE: envoy automatically adds: `Path`, `Status`, `Content-Length`, `WWWAuthenticate`, `Location`
                 allowed_client_headers:
                   patterns:
-                    ## NOTE: this is needed for oauth2-proxy cookie_refresh to work
+                    ## oauth2-proxy can return HTML content on failure (for its sign-in page)
+                    - exact: content-type
+                      ignore_case: true
+
+                    ## oauth2-proxy will set cookies during a cookie refresh flow
                     - exact: set-cookie
                       ignore_case: true
 
                 ## headers from oauth2-proxy that are sent back in the client response (on authentication success)
                 allowed_client_headers_on_success:
                   patterns:
-                    ## NOTE: this is needed for oauth2-proxy cookie_refresh to work
+                    ## oauth2-proxy will set cookies during a cookie refresh flow
                     - exact: set-cookie
                       ignore_case: true
     {{- end }}


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
closes https://github.com/deployKF/deployKF/issues/96

This PR tries to ensure that background queries do not get redirected to dex authentication (which will cause a CSRF cookie to be added to the browser), as around the cookie expiry time, we are seeing 431 errors (too large headers) due to too many CSRF cookies.

This PR makes two changes:

1. Ensures that `Accept` headers are actually passed to oauth2-proxy during ExtAuthZ:
     - This is because oauth2-proxy will not redirect `application/json` requests which are unauthenticated, and instead just responds with 401. (See [oauth2-proxy behavior](https://oauth2-proxy.github.io/oauth2-proxy/behaviour)). 
2. Defines [`--api-route` / `api_routes`](https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview#command-line-options) patterns for all paths that deployKF makes "background requests" to (but which don't use `application/json`), so aren't hit by the first change:
     - As far as I can tell, just checking for the presence of `/api/` or `/apis/` hits most of them, with the only significant remaining one being `/ml_metadata` from KFP.

---

__NOTE:__ This solution is inherently brittle, it requires us to manually keep the `api_routes` up to date, and users can still manually cause too many CSRF tokens (for example, by clicking around in Jupyter after your token expires). 

Therefore, we will also follow up PR with a phased approach to enable the oauth2-proxy "sign-in" page, which will mean that no CSRF cookie is added until a user clicks the "sign-in" button.

The "sign-in" page change will require two steps, because it will potentially break some "automatic login scripts", like the [`KFPClientManager`](https://www.deploykf.org/user-guides/access-kubeflow-pipelines-api/#dex-static-credentials) from our own docs:

1. __PHASE 1:__ Make enabling the sign-in page an optional value:
     - Disabled by default
     - Warn users to test it with their scripts
4. __PHASE 2:__ Enable sign-in page by default.