### PR TITLE
feat: enable setting registrationFlow in deploykf_dashboard

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -638,6 +638,11 @@ deploykf_core:
         tag: v1.7.0
         pullPolicy: IfNotPresent
 
+    ## enables automatic profile creation for users who log into Kubeflow for the first time
+    ## https://www.kubeflow.org/docs/components/central-dash/profiles/#automatic-profile-creation
+    ##
+    registrationFlow: false
+
     ## configs dashboard navigation
     ##
     navigation:

--- a/generator/templates/manifests/deploykf-core/deploykf-dashboard/values.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-dashboard/values.yaml
@@ -39,7 +39,7 @@ centralDashboard:
 
   ## the value of `REGISTRATION_FLOW` environment variable for central-dashboard
   ##
-  registrationFlow: false
+  registrationFlow: {{< .Values.deploykf_core.deploykf_dashboard.registrationFlow | quote >}}
 
   ## configs central-dashboard navigation
   ##


### PR DESCRIPTION
This allows for setting registrationFlow in deploykf_dashboard. This setting enables automatic profile creation for users who log into KubeFlow for the first time. More information on this feature found here: https://www.kubeflow.org/docs/components/central-dash/profiles/#automatic-profile-creation. 