### PR TITLE
improve: add robots.txt to deny all user-agents

### DIFF
--- a/generator/templates/manifests/deploykf-core/deploykf-auth/templates/oauth2-proxy/VirtualService.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-auth/templates/oauth2-proxy/VirtualService.yaml
@@ -18,6 +18,11 @@ spec:
       match:
         - uri:
             prefix: /oauth2/
+
+        ## we publish the robots.txt which is served by oauth2-proxy (deny all robots)
+        ## https://oauth2-proxy.github.io/oauth2-proxy/features/endpoints/
+        - uri:
+            exact: /robots.txt
       route:
         - destination:
             host: oauth2-proxy.{{ .Release.Namespace }}.svc.{{ .Values.deployKF.clusterDomain }}


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR adds a `robots.txt` to the root of the domain to discourage all scrapers from indexing deployKF platforms (which really should NOT be on the public internet). We achieve this by exposing the `robots.txt` that is [served by `oauth2-proxy`](https://oauth2-proxy.github.io/oauth2-proxy/features/endpoints/).

The contents of the `robots.txt` is as follows:

```
User-agent: *
Disallow: /
```

