### PR TITLE
fix: argocd sync script only seeing first app in each group

### DIFF
--- a/scripts/sync_argocd_apps.sh
+++ b/scripts/sync_argocd_apps.sh
@@ -290,8 +290,8 @@ function sync_argocd() {
   echo_blue "=========================================================================================="
 
   # find all applications that match the selector
-  local _app_names
-  read -r -a _app_names <<< "$(argocd app list -l "$_app_selector" -N "$_app_namespace" -o "name")"
+  local -a _app_names=()
+  read -r -a _app_names <<< "$(argocd app list -l "$_app_selector" -N "$_app_namespace" -o "name" | tr '\n' ' ')"
 
   # if no applications are found, fail if required
   if [[ ${#_app_names[@]} -eq 0 ]]; then


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR fixes a regression caused by https://github.com/deployKF/deployKF/pull/108, where only the first app in each sync group was being synced. Our bash splitting was not correcting parsing the newline-separated output of `argocd app list ...`. 