### PR TITLE
docs: update default argocd to 2.10.4

### DIFF
--- a/argocd-plugin/argocd-install/kustomization.yaml
+++ b/argocd-plugin/argocd-install/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 resources:
   ## TIP: this determines which version of ArgoCD is installed
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.9.6/manifests/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.10.4/manifests/install.yaml
 
   ## TIP: if you don't have a default storage class, you may need to set the `spec.storageClassName`
   ## TIP: if you have an HA argocd-repo-server deployment, you will need to make this a ReadWriteMany volume


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR updates the default version of ArgoCD (in the example docs) from `2.9.6` to `2.10.4`.

Hopefully, this will resolve the minio post-install job race condition for some users:
- https://github.com/orgs/deployKF/discussions/113