### PR TITLE
fix: require bash 4.4+ for sync script

### DIFF
--- a/scripts/sync_argocd_apps.sh
+++ b/scripts/sync_argocd_apps.sh
@@ -43,9 +43,9 @@ ARGOCD_WAIT_TIMEOUT_SECONDS="${ARGOCD_WAIT_TIMEOUT_SECONDS:-300}"
 # REQUIREMENTS
 #######################################
 
-# ensure bash version 4.2+
-if [[ ${BASH_VERSINFO[0]} -lt 4 || (${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -lt 2) ]]; then
-  echo ">>> ERROR: Bash version 4.2+ is required to run this script, current version: '${BASH_VERSION}'"
+# ensure bash version 4.4+
+if [[ ${BASH_VERSINFO[0]} -lt 4 || (${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -lt 4) ]]; then
+  echo ">>> ERROR: Bash version 4.4+ is required to run this script, current version: '${BASH_VERSION}'"
   exit 1
 fi
 


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
The required `bash` version for the `sync_argocd_apps.sh` script is actually 4.4+ (see https://github.com/deployKF/deployKF/issues/125).