### PR TITLE
feat: update dex to 2.39.1

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -449,7 +449,7 @@ deploykf_core:
     images:
       dex:
         repository: ghcr.io/dexidp/dex
-        tag: v2.37.0
+        tag: v2.39.1
         pullPolicy: IfNotPresent
 
       oauth2Proxy:

--- a/generator/templates/manifests/deploykf-core/deploykf-auth/templates/dex/Deployment.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-auth/templates/dex/Deployment.yaml
@@ -55,6 +55,11 @@ spec:
             - name: GOMPLATE_RIGHT_DELIM
               value: ">>"
 
+            ## connector configs don't provide a way to escape `$`, and can already read env vars with gomplate
+            ## https://github.com/dexidp/dex/pull/1902
+            - name: DEX_EXPAND_ENV
+              value: "false"
+
             {{- range $user:= .Values.dex.staticPasswords }}
             {{- if and $user.password.existingSecret $user.password.existingSecretKey }}
             {{- $password_env := include "deploykf-auth.dex.password_env" (dict "name" $user.password.existingSecret "key" $user.password.existingSecretKey) }}

--- a/generator/templates/manifests/deploykf-core/deploykf-auth/templates/oauth2-proxy/Secret-config.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-auth/templates/oauth2-proxy/Secret-config.yaml
@@ -107,6 +107,10 @@ skip_provider_button = false
 skip_provider_button = true
 {{- end }}
 
+## oauth2-proxy sends "force" by default, which causes dex to always prompt for login
+## https://github.com/dexidp/dex/pull/3086
+prompt = "none"
+
 ## oauth2-proxy does not verify nonce claim by default
 insecure_oidc_skip_nonce = false
 


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR updates dex to `2.39.1`.

The new version of Dex supports disabling env-var expansion in the config file by setting `DEX_EXPAND_ENV` to `false`, we have done this. This is useful because there was previously no way to escape literal `$` characters that may appear in the users `deploykf_core.deploykf_auth.dex.connectors` configs https://github.com/dexidp/dex/pull/1902.

We also tell `oauth2-proxy` to not explicitly "force" the provider to prompt the user for consent during each login, as Dex now respects this request as of https://github.com/dexidp/dex/pull/3086.