### PR TITLE
feat: update kubectl container to 1.26.15

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -459,7 +459,7 @@ deploykf_core:
 
       kubectl:
         repository: docker.io/bitnami/kubectl
-        tag: 1.26.6-debian-11-r8
+        tag: 1.26.15-debian-12-r4
         pullPolicy: IfNotPresent
 
     ## dex configs
@@ -1050,7 +1050,7 @@ deploykf_opt:
 
       kubectl:
         repository: docker.io/bitnami/kubectl
-        tag: 1.26.6-debian-11-r8
+        tag: 1.26.15-debian-12-r4
         pullPolicy: IfNotPresent
 
     ## persistence configs
@@ -1185,7 +1185,7 @@ deploykf_opt:
 
       kubectl:
         repository: docker.io/bitnami/kubectl
-        tag: 1.26.6-debian-11-r8
+        tag: 1.26.15-debian-12-r4
         pullPolicy: IfNotPresent
 
     ## persistence configs


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR updates the default kubectl container version to `1.26.15`.

This is used in things like pre-install jobs which generate secrets.