### PR TITLE
feat: update default istio to 1.17.8

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -234,13 +234,13 @@ deploykf_dependencies:
       istioBase:
         name: base
         ## NOTE: this version should be aligned with `deploykf_core.deploykf_istio_gateway.charts.istioGateway.version`
-        version: 1.17.3
+        version: 1.17.8
         repository: https://istio-release.storage.googleapis.com/charts
 
       istioDaemon:
         name: istiod
         ## NOTE: this version should be aligned with `deploykf_core.deploykf_istio_gateway.charts.istioGateway.version`
-        version: 1.17.3
+        version: 1.17.8
         repository: https://istio-release.storage.googleapis.com/charts
 
     ## image overrides
@@ -696,7 +696,7 @@ deploykf_core:
         enabled: true
         name: gateway
         ## NOTE: this version should be aligned with `deploykf_dependencies.istio.charts.istioDaemon.version`
-        version: 1.17.3
+        version: 1.17.8
         repository: https://istio-release.storage.googleapis.com/charts
 
     ## istio gateway configs


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR updates the default Istio version to `1.17.8`.

__WARNING:__ to fully update, users will need to use the new `update_istio_sidecars.sh` script added in https://github.com/deployKF/deployKF/pull/132

__NOTE 1:__ this version is still quite out of date, but as we don't want to break support for old versions of Kubernetes in a patch release, we will do a more significant jump in the next minor release.

__NOTE 2:__ you can update these values to any [supported version of Istio](https://www.deploykf.org/releases/version-matrix/#istio), if you want to use a newer version.