### PR TITLE
feat: update default minio to `RELEASE.2024-05-10T01-41-38Z`

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -1040,17 +1040,25 @@ deploykf_opt:
     images:
       minio:
         repository: docker.io/minio/minio
-        tag: RELEASE.2023-08-04T17-40-21Z
+        tag: RELEASE.2024-05-10T01-41-38Z
         pullPolicy: IfNotPresent
 
       minioMc:
-        repository: docker.io/minio/mc
-        tag: RELEASE.2023-08-01T23-30-57Z
+        ## NOTE: we copy `mc` to a volume for use in our init jobs. we use the bitnami image because `/usr/bin/mc`
+        ##       isn't readable by non-root in the official image: https://github.com/minio/mc/issues/4932
+        repository: docker.io/bitnami/minio-client
+        tag: 2024.5.9-debian-12-r0
         pullPolicy: IfNotPresent
 
       kubectl:
         repository: docker.io/bitnami/kubectl
         tag: 1.26.6-debian-11-r8
+        pullPolicy: IfNotPresent
+
+      shell:
+        ## NOTE: this image must have `bash`, `curl` and `jq` installed
+        repository: docker.io/bitnami/os-shell
+        tag: 12-debian-12-r20
         pullPolicy: IfNotPresent
 
     ## persistence configs

--- a/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Job-create-buckets.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Job-create-buckets.yaml
@@ -23,9 +23,14 @@ spec:
         app.kubernetes.io/component: minio
     spec:
       restartPolicy: OnFailure
-      {{- if .Values.minio.mcImage.pullSecret }}
+      {{- if or .Values.minio.mcImage.pullSecret .Values.minio.shellImage.pullSecret }}
       imagePullSecrets:
+        {{- if .Values.minio.mcImage.pullSecret }}
         - name: {{ .Values.minio.mcImage.pullSecret | quote }}
+        {{- end }}
+        {{- if .Values.minio.shellImage.pullSecret }}
+        - name: {{ .Values.minio.shellImage.pullSecret | quote }}
+        {{- end }}
       {{- end }}
       nodeSelector: {}
       affinity: {}
@@ -37,14 +42,30 @@ spec:
       {{- else }}
       securityContext: {}
       {{- end }}
-      initContainers: []
-      containers:
-        - name: create-buckets
+      initContainers:
+        - name: copy-mc
           image: {{ .Values.minio.mcImage.repository }}:{{ .Values.minio.mcImage.tag }}
-          imagePullPolicy: {{ .Values.minio.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.minio.mcImage.pullPolicy }}
           securityContext:
             runAsUser: {{ .Values.minio.mcImage.uid }}
             runAsGroup: {{ .Values.minio.mcImage.gid }}
+          command:
+            - "/bin/sh"
+            - "-c"
+          args:
+            - |
+              echo "copying 'mc' binary to shared volume...";
+              cp -f "$(which mc)" /shared-bin/mc;
+          volumeMounts:
+            - name: shared-bin
+              mountPath: "/shared-bin/"
+      containers:
+        - name: create-buckets
+          image: {{ .Values.minio.shellImage.repository }}:{{ .Values.minio.shellImage.tag }}
+          imagePullPolicy: {{ .Values.minio.shellImage.pullPolicy }}
+          securityContext:
+            runAsUser: {{ .Values.minio.shellImage.uid }}
+            runAsGroup: {{ .Values.minio.shellImage.gid }}
           command:
             - "/job-scripts/create_buckets.sh"
           args: []
@@ -76,6 +97,9 @@ spec:
             - name: mc-config
               ## we must mount a writable volume at the `/.mc/` path so that the `mc` command can store its configs
               mountPath: "/.mc/"
+            - name: shared-bin
+              mountPath: "/usr/local/bin/mc"
+              subPath: "mc"
             {{- if .Values.deployKF_helpers.deploykf_gateway.is_self_signed_cert }}
             - name: gateway-root-ca-cert
               mountPath: "/.mc/certs/CAs/"
@@ -90,6 +114,8 @@ spec:
                 path: create_buckets.sh
                 mode: 0755
         - name: mc-config
+          emptyDir: {}
+        - name: shared-bin
           emptyDir: {}
         {{- if .Values.deployKF_helpers.deploykf_gateway.is_self_signed_cert }}
         - name: gateway-root-ca-cert

--- a/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Job-create-policies.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Job-create-policies.yaml
@@ -23,9 +23,14 @@ spec:
         app.kubernetes.io/component: minio
     spec:
       restartPolicy: OnFailure
-      {{- if .Values.minio.mcImage.pullSecret }}
+      {{- if or .Values.minio.mcImage.pullSecret .Values.minio.shellImage.pullSecret }}
       imagePullSecrets:
+        {{- if .Values.minio.mcImage.pullSecret }}
         - name: {{ .Values.minio.mcImage.pullSecret | quote }}
+        {{- end }}
+        {{- if .Values.minio.shellImage.pullSecret }}
+        - name: {{ .Values.minio.shellImage.pullSecret | quote }}
+        {{- end }}
       {{- end }}
       nodeSelector: {}
       affinity: {}
@@ -37,14 +42,30 @@ spec:
       {{- else }}
       securityContext: {}
       {{- end }}
-      initContainers: []
-      containers:
-        - name: create-policies
+      initContainers:
+        - name: copy-mc
           image: {{ .Values.minio.mcImage.repository }}:{{ .Values.minio.mcImage.tag }}
-          imagePullPolicy: {{ .Values.minio.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.minio.mcImage.pullPolicy }}
           securityContext:
             runAsUser: {{ .Values.minio.mcImage.uid }}
             runAsGroup: {{ .Values.minio.mcImage.gid }}
+          command:
+            - "/bin/sh"
+            - "-c"
+          args:
+            - |
+              echo "copying 'mc' binary to shared volume...";
+              cp -f "$(which mc)" /shared-bin/mc;
+          volumeMounts:
+            - name: shared-bin
+              mountPath: "/shared-bin/"
+      containers:
+        - name: create-policies
+          image: {{ .Values.minio.shellImage.repository }}:{{ .Values.minio.shellImage.tag }}
+          imagePullPolicy: {{ .Values.minio.shellImage.pullPolicy }}
+          securityContext:
+            runAsUser: {{ .Values.minio.shellImage.uid }}
+            runAsGroup: {{ .Values.minio.shellImage.gid }}
           command:
             - "/job-scripts/create_policies.sh"
           args: []
@@ -78,6 +99,9 @@ spec:
               mountPath: "/.mc/"
             - name: minio-policies
               mountPath: "/minio-policies/"
+            - name: shared-bin
+              mountPath: "/usr/local/bin/mc"
+              subPath: "mc"
             {{- if .Values.deployKF_helpers.deploykf_gateway.is_self_signed_cert }}
             - name: gateway-root-ca-cert
               mountPath: "/.mc/certs/CAs/"
@@ -96,6 +120,8 @@ spec:
         - name: minio-policies
           configMap:
             name: deploykf-minio-policies
+        - name: shared-bin
+          emptyDir: {}
         {{- if .Values.deployKF_helpers.deploykf_gateway.is_self_signed_cert }}
         - name: gateway-root-ca-cert
           configMap:

--- a/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Job-create-service-accounts.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Job-create-service-accounts.yaml
@@ -23,13 +23,16 @@ spec:
         app.kubernetes.io/component: minio
     spec:
       restartPolicy: OnFailure
-      {{- if or .Values.minio.mcImage.pullSecret .Values.minio.kubectlImage.pullSecret }}
+      {{- if or .Values.minio.mcImage.pullSecret .Values.minio.kubectlImage.pullSecret .Values.minio.shellImage.pullSecret }}
       imagePullSecrets:
         {{- if .Values.minio.mcImage.pullSecret }}
         - name: {{ .Values.minio.mcImage.pullSecret | quote }}
         {{- end }}
         {{- if .Values.minio.kubectlImage.pullSecret }}
         - name: {{ .Values.minio.kubectlImage.pullSecret | quote }}
+        {{- end }}
+        {{- if .Values.minio.shellImage.pullSecret }}
+        - name: {{ .Values.minio.shellImage.pullSecret | quote }}
         {{- end }}
       {{- end }}
       nodeSelector: {}
@@ -43,6 +46,22 @@ spec:
       securityContext: {}
       {{- end }}
       initContainers:
+        - name: copy-mc
+          image: {{ .Values.minio.mcImage.repository }}:{{ .Values.minio.mcImage.tag }}
+          imagePullPolicy: {{ .Values.minio.mcImage.pullPolicy }}
+          securityContext:
+            runAsUser: {{ .Values.minio.mcImage.uid }}
+            runAsGroup: {{ .Values.minio.mcImage.gid }}
+          command:
+            - "/bin/sh"
+            - "-c"
+          args:
+            - |
+              echo "copying 'mc' binary to shared volume...";
+              cp -f "$(which mc)" /shared-bin/mc;
+          volumeMounts:
+            - name: shared-bin
+              mountPath: "/shared-bin/"
         - name: copy-kubectl
           image: {{ .Values.minio.kubectlImage.repository }}:{{ .Values.minio.kubectlImage.tag }}
           imagePullPolicy: {{ .Values.minio.kubectlImage.pullPolicy }}
@@ -54,18 +73,18 @@ spec:
             - "-c"
           args:
             - |
-              echo "copying kubectl binary to shared volume...";
+              echo "copying 'kubectl' binary to shared volume...";
               cp -f "$(which kubectl)" /shared-bin/kubectl;
           volumeMounts:
             - name: shared-bin
               mountPath: "/shared-bin/"
       containers:
         - name: create-service-accounts
-          image: {{ .Values.minio.mcImage.repository }}:{{ .Values.minio.mcImage.tag }}
-          imagePullPolicy: {{ .Values.minio.image.pullPolicy }}
+          image: {{ .Values.minio.shellImage.repository }}:{{ .Values.minio.shellImage.tag }}
+          imagePullPolicy: {{ .Values.minio.shellImage.pullPolicy }}
           securityContext:
-            runAsUser: {{ .Values.minio.mcImage.uid }}
-            runAsGroup: {{ .Values.minio.mcImage.gid }}
+            runAsUser: {{ .Values.minio.shellImage.uid }}
+            runAsGroup: {{ .Values.minio.shellImage.gid }}
           command:
             - "/job-scripts/create_service_accounts.sh"
           args: []
@@ -126,6 +145,9 @@ spec:
             - name: mc-config
               ## we must mount a writable volume at the `/.mc/` path so that the `mc` command can store its configs
               mountPath: "/.mc/"
+            - name: shared-bin
+              mountPath: "/usr/local/bin/mc"
+              subPath: "mc"
             - name: shared-bin
               mountPath: "/usr/local/bin/kubectl"
               subPath: "kubectl"

--- a/generator/templates/manifests/deploykf-opt/deploykf-minio/values.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-minio/values.yaml
@@ -89,6 +89,16 @@ minio:
     uid: 1000
     gid: 1000
 
+  ## configs for the os-shell container image
+  ##
+  shellImage:
+    repository: {{< .Values.deploykf_opt.deploykf_minio.images.shell.repository | quote >}}
+    tag: {{< .Values.deploykf_opt.deploykf_minio.images.shell.tag | quote >}}
+    pullPolicy: {{< .Values.deploykf_opt.deploykf_minio.images.shell.pullPolicy | quote >}}
+    pullSecret: ""
+    uid: 1000
+    gid: 1000
+
   ## the securityContext configs for minio Pods
   ## - spec for PodSecurityContext:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR updates the default MinIO version to `RELEASE.2024-05-10T01-41-38Z`.

__NOTE:__ because the `minio/mc` docker image has had all non `mc` binaries removed (specifically, `curl` and `jq`), we now use a combination of the following images for our pre-install jobs (which do things like generating S3-like access key secrets for KFP):

- `docker.io/bitnami/minio-client:2024.5.9-debian-12-r0` (for the `mc` binary)
- `docker.io/bitnami/os-shell:12-debian-12-r20` (for the `curl` and `jq` binaries, and to actually run the jobs)