### PR TITLE
feat: update profile-controller and kfam to 1.8.0

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -630,12 +630,12 @@ deploykf_core:
 
       profileController:
         repository: kubeflownotebookswg/profile-controller
-        tag: v1.7.0
+        tag: v1.8.0
         pullPolicy: IfNotPresent
 
       kfamApi:
         repository: kubeflownotebookswg/kfam
-        tag: v1.7.0
+        tag: v1.8.0
         pullPolicy: IfNotPresent
 
     ## configs dashboard navigation

--- a/generator/templates/manifests/deploykf-core/deploykf-dashboard/templates/kfam-api/Deployment.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-dashboard/templates/kfam-api/Deployment.yaml
@@ -44,6 +44,14 @@ spec:
           resources:
           {{- toYaml .Values.kfamAPI.resources | nindent 12 }}
           {{- end }}
+          env:
+            ## Istio AuthorizationPolicy principal configs
+            ## https://github.com/kubeflow/kubeflow/blob/v1.8.0/components/access-management/kfam/bindings.go#L80-L86
+            - name: ISTIO_INGRESS_GATEWAY_PRINCIPAL
+              value: "{{ .Values.deployKF.clusterDomain }}/ns/{{ .Values.deployKF.gateway.namespace }}/sa/{{ .Values.deployKF.gateway.serviceAccount }}"
+            - name: KFP_UI_PRINCIPAL
+              ## TODO: there should be a way to unset this when not using kubeflow pipelines
+              value: "{{ .Values.deployKF.clusterDomain }}/ns/{{ .Values.deployKF.kubeflow.namespace }}/sa/{{ .Values.deployKF.kubeflow.pipelines.frontend.serviceAccount }}"
           command:
             - /access-management
             - -userid-header

--- a/generator/templates/manifests/deploykf-core/deploykf-dashboard/templates/profile-controller/Deployment.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-dashboard/templates/profile-controller/Deployment.yaml
@@ -46,6 +46,17 @@ spec:
           resources:
           {{- toYaml .Values.profileController.resources | nindent 12 }}
           {{- end }}
+          env:
+            ## Istio AuthorizationPolicy principal configs
+            ## https://github.com/kubeflow/kubeflow/blob/v1.8.0/components/profile-controller/controllers/profile_controller.go#L420-L430
+            - name: ISTIO_INGRESS_GATEWAY_PRINCIPAL
+              value: "{{ .Values.deployKF.clusterDomain }}/ns/{{ .Values.deployKF.gateway.namespace }}/sa/{{ .Values.deployKF.gateway.serviceAccount }}"
+            - name: NOTEBOOK_CONTROLLER_PRINCIPAL
+              ## TODO: there should be a way to unset this when not using kubeflow notebooks
+              value: "{{ .Values.deployKF.clusterDomain }}/ns/{{ .Values.deployKF.kubeflow.namespace }}/sa/{{ .Values.deployKF.kubeflow.notebooks.controller.serviceAccount }}"
+            - name: KFP_UI_PRINCIPAL
+              ## TODO: there should be a way to unset this when not using kubeflow pipelines
+              value: "{{ .Values.deployKF.clusterDomain }}/ns/{{ .Values.deployKF.kubeflow.namespace }}/sa/{{ .Values.deployKF.kubeflow.pipelines.frontend.serviceAccount }}"
           command:
             - /manager
             - -userid-header

--- a/generator/templates/manifests/deploykf-core/deploykf-dashboard/values.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-dashboard/values.yaml
@@ -10,7 +10,14 @@ deployKF:
   clusterDomain: cluster.local
 
   kubeflow:
+    namespace: kubeflow
     useridHeader: kubeflow-userid
+    notebooks:
+      controller:
+        serviceAccount: notebook-controller-service-account
+    pipelines:
+      frontend:
+        serviceAccount: ml-pipeline-ui
 
   gateway:
     namespace: {{< .Values.deploykf_core.deploykf_istio_gateway.namespace | quote >}}
@@ -185,8 +192,9 @@ profileController:
     tag: {{< .Values.deploykf_core.deploykf_dashboard.images.profileController.tag | quote >}}
     pullPolicy: {{< .Values.deploykf_core.deploykf_dashboard.images.profileController.pullPolicy | quote >}}
     pullSecret: ""
-    uid: 0
-    gid: 0
+    ## https://github.com/GoogleContainerTools/distroless/blob/761e3d2e151f080ed5c80cd1f26c12d68bd89ad9/common/variables.bzl#L18
+    uid: 65532
+    gid: 65532
 
   ## resource requests/limits for the profile-controller Pods
   ## - spec for ResourceRequirements:
@@ -228,8 +236,9 @@ kfamAPI:
     tag: {{< .Values.deploykf_core.deploykf_dashboard.images.kfamApi.tag | quote >}}
     pullPolicy: {{< .Values.deploykf_core.deploykf_dashboard.images.kfamApi.pullPolicy | quote >}}
     pullSecret: ""
-    uid: 0
-    gid: 0
+    ## https://github.com/GoogleContainerTools/distroless/blob/761e3d2e151f080ed5c80cd1f26c12d68bd89ad9/common/variables.bzl#L18
+    uid: 65532
+    gid: 65532
 
   ## resource requests/limits for the kfam-api Pods
   ## - spec for ResourceRequirements:

--- a/generator/templates/manifests/deploykf-core/deploykf-profiles-generator/templates/profile.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-profiles-generator/templates/profile.yaml
@@ -54,41 +54,4 @@ spec:
   {{- else }}
   resourceQuotaSpec: {}
   {{- end }}
----
-{{- /*
-The Kubeflow Profile Controller generates an `AuthorizationPolicy/ns-owner-access-istio` in each profile which dooes
-not check the source principal for its `request.headers[kubeflow-userid]` rule, this mean anyone can access any pod
-in the profile namespace by simply setting the "kubeflow-userid" header to the owner's email.
-
-This AuthorizationPolicy explicitly checks for traffic attemptign this bypass and denies it.
-
-TODO: this issue should be patched in a future release of the upstream Kubeflow Profile Controller
-*/}}
-apiVersion: security.istio.io/v1beta1
-kind: AuthorizationPolicy
-metadata:
-  name: ns-owner-access-istio--override
-  namespace: {{ $profile_name | quote }}
-  labels:
-    helm.sh/chart: {{ include "deploykf-profiles-generator.labels.chart" $ }}
-    app.kubernetes.io/name: {{ include "deploykf-profiles-generator.labels.name" $ }}
-    app.kubernetes.io/instance: {{ $.Release.Name }}
-    app.kubernetes.io/managed-by: {{ $.Release.Service }}
-spec:
-  action: DENY
-  rules:
-    ## deny requests with "kubeflow-userid" header set to "admin@example.com" if they do not come from safe sources
-    - from:
-        - source:
-            notPrincipals:
-              - "{{ $.Values.deployKF.clusterDomain }}/ns/{{ $.Values.deployKF.gateway.namespace }}/sa/{{ $.Values.deployKF.gateway.serviceAccount }}"
-              {{- if $.Values.deployKF.kubeflow.pipelines.enabled }}
-              ## the `ml-pipeline-ui` pod will proxy some requests into the user's namespace,
-              ## for example, to view logs on the object store
-              - "{{ $.Values.deployKF.clusterDomain }}/ns/{{ $.Values.deployKF.kubeflow.pipelines.pipelineUI.namespace }}/sa/{{ $.Values.deployKF.kubeflow.pipelines.pipelineUI.serviceAccount }}"
-              {{- end }}
-      when:
-        - key: request.headers[{{ $.Values.deployKF.kubeflow.useridHeader }}]
-          values:
-            - {{ $profile_ownerEmail | quote }}
 {{- end }}


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR updates the `profile-controller` and `kfam-api` to their 1.8.0 versions.

This allows us to remove the `ns-owner-access-istio--override` AuthorizationPolicy in each Profile Namespace, as the upstream profile controller will now correctly create the `ns-owner-access-istio` AuthorizationPolicy with source principals.

Additionally, this change means these core components now have native ARM64 Docker images.

I also realised we were needlessly setting the UID/GID of the Pods to `0`, when we can use [the non-root `65532`](https://github.com/GoogleContainerTools/distroless/blob/761e3d2e151f080ed5c80cd1f26c12d68bd89ad9/common/variables.bzl#L18) for distroless images.