### PR TITLE
feat: update dashboard to 0.1.1 + update sidebar links

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -625,7 +625,7 @@ deploykf_core:
     images:
       dashboard:
         repository: ghcr.io/deploykf/dashboard
-        tag: 0.1.0
+        tag: 0.1.1
         pullPolicy: IfNotPresent
 
       profileController:

--- a/generator/templates/manifests/deploykf-core/deploykf-dashboard/templates/central-dashboard/VirtualService.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-dashboard/templates/central-dashboard/VirtualService.yaml
@@ -14,6 +14,75 @@ spec:
   hosts:
     - {{ .Values.deployKF.gateway.hostname | quote }}
   http:
+    ## deny adding profile contributors
+    - match:
+        - ignoreUriCase: true
+          uri:
+            prefix: /api/workgroup/add-contributor
+          method:
+            exact: POST
+      directResponse:
+        status: 403
+        body:
+          string: |-
+            { "error": "deployKF does not support adding profile contributors with the dashboard." }
+      headers:
+        response:
+          set:
+            content-type: application/json
+
+    ## deny removing profile contributors
+    - match:
+        - ignoreUriCase: true
+          uri:
+            prefix: /api/workgroup/remove-contributor
+          method:
+            exact: DELETE
+      directResponse:
+        status: 403
+        body:
+          string: |-
+            { "error": "deployKF does not support removing profile contributors with the dashboard." }
+      headers:
+        response:
+          set:
+            content-type: application/json
+
+    ## deny creating profiles
+    - match:
+        - ignoreUriCase: true
+          uri:
+            prefix: /api/workgroup/create
+          method:
+            exact: POST
+      directResponse:
+        status: 403
+        body:
+          string: |-
+            { "error": "deployKF does not support creating profiles with the dashboard." }
+      headers:
+        response:
+          set:
+            content-type: application/json
+
+    ## deny deleting profiles
+    - match:
+        - ignoreUriCase: true
+          uri:
+            prefix: /api/workgroup/nuke-self
+          method:
+            exact: DELETE
+      directResponse:
+        status: 403
+        body:
+          string: |-
+            { "error": "deployKF does not support deleting profiles with the dashboard." }
+      headers:
+        response:
+          set:
+            content-type: application/json
+
+    ## route all other requests to the central-dashboard service
     - match:
         - uri:
             prefix: /

--- a/generator/templates/manifests/deploykf-core/deploykf-dashboard/templates/kfam-api/AuthorizationPolicy-deny.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-dashboard/templates/kfam-api/AuthorizationPolicy-deny.yaml
@@ -1,0 +1,39 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: kfam-api-deny
+  labels:
+    helm.sh/chart: {{ include "deploykf-dashboard.labels.chart" . }}
+    app.kubernetes.io/name: {{ include "deploykf-dashboard.labels.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: kfam-api
+spec:
+  action: DENY
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "deploykf-dashboard.labels.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/component: kfam-api
+  rules:
+    - to:
+        ## disable "create role binding" operation (deployKF manages profiles with values)
+        - operation:
+            ports:
+              - "8081"
+            methods:
+              - POST
+            paths:
+              - /kfam/v1/bindings
+              - /kfam/v1/bindings/**
+
+        ## disable "delete role binding" operation (deployKF manages profiles with values)
+        - operation:
+            ports:
+              - "8081"
+            methods:
+              - DELETE
+            paths:
+              - /kfam/v1/bindings
+              - /kfam/v1/bindings/**

--- a/generator/templates/manifests/deploykf-core/deploykf-dashboard/values.yaml
+++ b/generator/templates/manifests/deploykf-core/deploykf-dashboard/values.yaml
@@ -28,8 +28,8 @@ centralDashboard:
     tag: {{< .Values.deploykf_core.deploykf_dashboard.images.dashboard.tag | quote >}}
     pullPolicy: {{< .Values.deploykf_core.deploykf_dashboard.images.dashboard.pullPolicy | quote >}}
     pullSecret: ""
-    uid: 0
-    gid: 0
+    uid: 1000
+    gid: 1000
 
   ## resource requests/limits for the central-dashboard Pods
   ## - spec for ResourceRequirements:
@@ -54,17 +54,17 @@ centralDashboard:
         icon: book
         link: "/jupyter/"
       {{<- end >}}
+      {{<- if .Values.kubeflow_tools.tensorboards.enabled >}}
+      - type: item
+        text: TensorBoards
+        icon: assessment
+        link: "/tensorboards/"
+      {{<- end >}}
       {{<- if .Values.kubeflow_tools.volumes.enabled >}}
       - type: item
         text: Volumes
         icon: device:storage
         link: "/volumes/"
-      {{<- end >}}
-      {{<- if .Values.kubeflow_tools.tensorboards.enabled >}}
-      - type: item
-        text: Tensorboards
-        icon: assessment
-        link: "/tensorboards/"
       {{<- end >}}
       {{<- if .Values.kubeflow_tools.katib.enabled >}}
       - type: item
@@ -73,30 +73,28 @@ centralDashboard:
         link: "/katib/"
       {{<- end >}}
       {{<- if .Values.kubeflow_tools.pipelines.enabled >}}
-      - type: item
-        text: KFP - Pipelines
+      - type: section
+        text: Pipelines
         icon: kubeflow:pipeline-centered
-        link: "/pipeline/#/pipelines"
-      - type: item
-        text: KFP - Experiments
-        icon: done-all
-        link: "/pipeline/#/experiments"
-      - type: item
-        text: KFP - Runs
-        icon: maps:directions-run
-        link: "/pipeline/#/runs"
-      - type: item
-        text: KFP - Recurring Runs
-        icon: device:access-alarm
-        link: "/pipeline/#/recurringruns"
-      - type: item
-        text: KFP - Artifacts
-        icon: editor:bubble-chart
-        link: "/pipeline/#/artifacts"
-      - type: item
-        text: KFP - Executions
-        icon: av:play-arrow
-        link: "/pipeline/#/executions"
+        items:
+          - type: item
+            text: Pipelines
+            link: "/pipeline/#/pipelines"
+          - type: item
+            text: Experiments
+            link: "/pipeline/#/experiments"
+          - type: item
+            text: Runs
+            link: "/pipeline/#/runs"
+          - type: item
+            text: Recurring Runs
+            link: "/pipeline/#/recurringruns"
+          - type: item
+            text: Artifacts
+            link: "/pipeline/#/artifacts"
+          - type: item
+            text: Executions
+            link: "/pipeline/#/executions"
       {{<- end >}}
 
     ## external links that appear in the sidebar
@@ -108,9 +106,9 @@ centralDashboard:
         text: Argo Server
         icon: settings-input-composite
         {{<- if .Values.deploykf_core.deploykf_istio_gateway.gateway.tls.clientsUseHttps >}}
-        link: "https://argo-server.{{< tmpl.Exec "deploykf_gateway.https_endpoint" . >}}"
+        link: "https://argo-server.{{< tmpl.Exec "deploykf_gateway.https_endpoint" . >}}/workflows/{ns}"
         {{<- else >}}
-        link: "http://argo-server.{{< tmpl.Exec "deploykf_gateway.http_endpoint" . >}}"
+        link: "http://argo-server.{{< tmpl.Exec "deploykf_gateway.http_endpoint" . >}}/workflows/{ns}"
         {{<- end >}}
       {{<- end >}}
       {{<- if .Values.deploykf_opt.deploykf_minio.enabled >}}


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR updates the deployKF Dashboard to [0.1.1](https://github.com/deployKF/dashboard/releases/tag/v0.1.1), this comes with numerous security and feature updates.

This PR also does the following:

- updates the sidebar links of the dashboard so that the Kubeflow Pipelines links are in their own section, which reduces clutter as there are so many.
- updates the Argo Server link to ensure users don't get confused by trying to list workflows at the cluster level (which happens if no namespace selector is applied), which causes RBAC errors as no normal user can do this.
- explicitly denies profiles owners the ability to manage profile contributors in the UI, as this should be done with deployKF values in GitOps

