### PR TITLE
feat: update default notebook images to 1.8.0

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -1478,15 +1478,15 @@ kubeflow_tools:
       ##
       image:
         ## the default container image
-        value: kubeflownotebookswg/jupyter-scipy:v1.7.0
+        value: kubeflownotebookswg/jupyter-scipy:v1.8.0
 
         ## the list of available container images in the dropdown
         options:
-          - kubeflownotebookswg/jupyter-scipy:v1.7.0
-          - kubeflownotebookswg/jupyter-pytorch-full:v1.7.0
-          - kubeflownotebookswg/jupyter-pytorch-cuda-full:v1.7.0
-          - kubeflownotebookswg/jupyter-tensorflow-full:v1.7.0
-          - kubeflownotebookswg/jupyter-tensorflow-cuda-full:v1.7.0
+          - kubeflownotebookswg/jupyter-scipy:v1.8.0
+          - kubeflownotebookswg/jupyter-pytorch-full:v1.8.0
+          - kubeflownotebookswg/jupyter-pytorch-cuda-full:v1.8.0
+          - kubeflownotebookswg/jupyter-tensorflow-full:v1.8.0
+          - kubeflownotebookswg/jupyter-tensorflow-cuda-full:v1.8.0
 
       ## VSCode-like Container Images (Group 1)
       ##  - the `imageGroupOne` section is used for "VSCode-like" apps that
@@ -1498,11 +1498,11 @@ kubeflow_tools:
       ##
       imageGroupOne:
         ## the default container image
-        value: kubeflownotebookswg/codeserver-python:v1.7.0
+        value: kubeflownotebookswg/codeserver-python:v1.8.0
 
         ## the list of available container images in the dropdown
         options:
-          - kubeflownotebookswg/codeserver-python:v1.7.0
+          - kubeflownotebookswg/codeserver-python:v1.8.0
 
       ## RStudio-like Container Images (Group 2)
       ##  - the `imageGroupTwo` section is used for "RStudio-like" apps whose
@@ -1516,11 +1516,11 @@ kubeflow_tools:
       ##
       imageGroupTwo:
         ## the default container image
-        value: kubeflownotebookswg/rstudio-tidyverse:v1.7.0
+        value: kubeflownotebookswg/rstudio-tidyverse:v1.8.0
 
         ## the list of available container images in the dropdown
         options:
-          - kubeflownotebookswg/rstudio-tidyverse:v1.7.0
+          - kubeflownotebookswg/rstudio-tidyverse:v1.8.0
 
       ## CPU Resources
       ##


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR updates the default Kubeflow Notebooks images to use the upstream `1.8.0` tags.

This is a significant update that we worked on upstream in https://github.com/kubeflow/kubeflow/pull/7357 and https://github.com/kubeflow/kubeflow/pull/7398 which comes with ARM64 support for all non-CUDA images and many other updates.

In the near future, we will create official deployKF notebook images with versions aligned to deployKF and other useful changes that you will be able to base your custom images on. However, we still recommend updating your images to these 1.8.0 versions in the meantime.

__NOTE:__ you will need to manually delete and recreate all your Notebook servers for this change to take effect, this update ___only affects the SPAWNER UI___, not existing notebooks.