### PR TITLE
fix: minio not starting, upstream removed curl

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -1039,8 +1039,10 @@ deploykf_opt:
     ##
     images:
       minio:
-        repository: docker.io/minio/minio
-        tag: RELEASE.2024-05-10T01-41-38Z
+        ## NOTE: we use the bitnami image because the upstream image does not contain `curl` and we
+        ##       need it to run checks before starting minio: https://github.com/minio/minio/issues/18373
+        repository: docker.io/bitnami/minio
+        tag: 2024.5.10-debian-12-r2
         pullPolicy: IfNotPresent
 
       minioMc:

--- a/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Deployment.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Deployment.yaml
@@ -131,6 +131,8 @@ spec:
             - "/bin/bash"
             - "-c"
           args:
+            ## NOTE: the istio mesh is NOT available in initContainers, so this check must be done in the main container
+            ##       https://github.com/istio/istio/issues/11130#issuecomment-2126255390
             - |
               ## if Minio can't GET the OPENID URL on start, it never tries again
               ## so we must ensure the URL is reachable before starting Minio
@@ -154,12 +156,11 @@ spec:
               done
 
               ## run minio
-              exec /usr/bin/docker-entrypoint.sh \
-                minio server \
-                  "/minio-data" \
-                  --address=:9000 \
-                  --console-address=:9001 \
-                  --certs-dir=/etc/minio/certs/
+              exec minio server \
+                "/minio-data" \
+                --address=:9000 \
+                --console-address=:9001 \
+                --certs-dir=/etc/minio/certs/
           ports:
             - name: http-api
               containerPort: 9000


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR fixes an error introduced by https://github.com/deployKF/deployKF/pull/158 (which was never part of a release).

The issue is that `curl` has been removed from the upstream MinIO images (`docker.io/minio/minio)`. Therefore, in this PR we have moved to the Bitnami ones (`docker.io/bitnami/minio`), as they have no pull limit on Dockerhub and still contain the `curl` binary.

For reference, we need the curl binary to check that dex is up before starting MinIO. If dex is not up before MinIO starts, then it will never try to access the OpenID provider again, and there will be no way to log in.