### PR TITLE
fix: stop embedded mysql log spam about `mysql_native_password`

### DIFF
--- a/generator/default_values.yaml
+++ b/generator/default_values.yaml
@@ -1288,6 +1288,7 @@ deploykf_opt:
       [mysqld]
       disable_log_bin
       default_authentication_plugin=mysql_native_password
+      log_error_suppression_list='MY-013360'
 
 
 ## --------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR stops the embedded MySQL instance from constantly printing the following logs:

```
[Warning] [MY-013360] [Server] Plugin mysql_native_password reported: ''mysql_native_password' is deprecated and will be removed in a future release. Please use caching_sha2_password instead'
[Warning] [MY-013360] [Server] Plugin mysql_native_password reported: ''mysql_native_password' is deprecated and will be removed in a future release. Please use caching_sha2_password instead'
[Warning] [MY-013360] [Server] Plugin mysql_native_password reported: ''mysql_native_password' is deprecated and will be removed in a future release. Please use caching_sha2_password instead'
[Warning] [MY-013360] [Server] Plugin mysql_native_password reported: ''mysql_native_password' is deprecated and will be removed in a future release. Please use caching_sha2_password instead'
```

__NOTE:__ can't avoid using `mysql_native_password` because Kubeflow Pipelines currently does not support `caching_sha2_password` (https://github.com/kubeflow/pipelines/issues/9549).