### PR TITLE
fix: cases of perpetual "out of sync" apps

### DIFF
--- a/generator/templates/argocd/applications/deploykf-dependencies/istio.yaml
+++ b/generator/templates/argocd/applications/deploykf-dependencies/istio.yaml
@@ -41,7 +41,6 @@ spec:
     ## istio patches the `failurePolicy` from "Ignore" to "Fail" once the webhook is up
     - group: admissionregistration.k8s.io
       kind: ValidatingWebhookConfiguration
-      name: istiod-default-validator
       jqPathExpressions:
         - ".webhooks[]?.failurePolicy"
     {{<- if .Values.kubernetes.azure.admissionsEnforcerFix >}}

--- a/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Deployment.yaml
+++ b/generator/templates/manifests/deploykf-opt/deploykf-minio/templates/minio/Deployment.yaml
@@ -30,6 +30,10 @@ spec:
         {{- if not .Values.minio.rootUser.existingSecret }}
         checksum/root-user: {{ include (print $.Template.BasePath "/minio/Secret-root-user.yaml") . | sha256sum }}
         {{- end }}
+        ## because we use a 'deploykf.org/restart-trigger' annotation to restart the deployment
+        ## there needs to be at least one normal annotation, otherwise argocd will show it as
+        ## "out of sync" after a secret change (it wants to remove the `annotations` field entirely)
+        dummy: "stops ArgoCD from removing the annotations field"
       labels:
         app.kubernetes.io/name: {{ include "deploykf-minio.labels.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}

--- a/generator/templates/manifests/kubeflow-tools/pipelines/patches/patch-cache-server-deployment.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/patches/patch-cache-server-deployment.yaml
@@ -4,6 +4,12 @@ metadata:
   name: cache-server
 spec:
   template:
+    metadata:
+      annotations:
+        ## because we use a 'deploykf.org/restart-trigger' annotation to restart the deployment
+        ## there needs to be at least one normal annotation, otherwise argocd will show it as
+        ## "out of sync" after a secret change (it wants to remove the `annotations` field entirely)
+        dummy: "stops ArgoCD from removing the annotations field"
     spec:
       containers:
         - name: server

--- a/generator/templates/manifests/kubeflow-tools/pipelines/patches/patch-metadata-grpc-deployment-deployment.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/patches/patch-metadata-grpc-deployment-deployment.yaml
@@ -4,6 +4,12 @@ metadata:
   name: metadata-grpc-deployment
 spec:
   template:
+    metadata:
+      annotations:
+        ## because we use a 'deploykf.org/restart-trigger' annotation to restart the deployment
+        ## there needs to be at least one normal annotation, otherwise argocd will show it as
+        ## "out of sync" after a secret change (it wants to remove the `annotations` field entirely)
+        dummy: "stops ArgoCD from removing the annotations field"
     spec:
       containers:
         - name: container

--- a/generator/templates/manifests/kubeflow-tools/pipelines/resources/profile-resources.yaml
+++ b/generator/templates/manifests/kubeflow-tools/pipelines/resources/profile-resources.yaml
@@ -490,6 +490,11 @@ spec:
       app: ml-pipeline-ui-artifact
   template:
     metadata:
+      annotations:
+        ## because we use a 'deploykf.org/restart-trigger' annotation to restart the deployment
+        ## there needs to be at least one normal annotation, otherwise argocd will show it as
+        ## "out of sync" after a secret change (it wants to remove the `annotations` field entirely)
+        dummy: "stops ArgoCD from removing the annotations field"
       labels:
         app: ml-pipeline-ui-artifact
     spec:


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR fixes a few cases where the ArgoCD apps would perpetually show as "out of sync", even after they were just synced.

- __`dkf-dep--istio`:__
     - The new Istio 1.22 added a new `ValidatingWebhookConfiguration` called `istio-validator-istio-system`, so we need to also ignore diffs in its `failurePolicy` (as Istio updates this to `Fail` after Istio is successfully running).
     - We now just ignore the `failurePolicy` of all validation webhooks in the istio app.
- __`kf-tools--pipelines`:__
     - If the MySQL secret was changed, Kyverno would restart the KFP pods that use it by updating the `deploykf.org/restart-trigger` annotation of the Pod template. However, because two of the deployments did not have `spec.template.metadata.annotations` at all, our ArgoCD `ignoreDifferences` did not work properly, ArgoCD wanted to remove the `annotations` field entirely. 
     - We have resolved this by adding a dummy annotation to these Deployments Pod templates:
         - `Deployment/cache-server` (in `kubeflow` namespace)
         - `Deployment/metadata-grpc-deployment` (in `kubeflow` namespace)
         - `Deployment/ml-pipeline-ui-artifact` (in each profile namespace). 
- __`dkf-opt--deploykf-minio`:__
     - To avoid issues with restart triggers (from OIDC secret and ObjectStore credentials), we have added a dummy annotation to the `Deployment/deploykf-minio` Pod template.

__WARNING:__ while testing this, I found a another issue, which is that even Kyverno 1.10.0 seems to display this upstream error (where if the source secret name is too long, the mutate rule will fail): https://github.com/kyverno/kyverno/issues/9134 We need to update the default Kyverno to one that has this fixed (or replace it if there are other issues in the newest version).